### PR TITLE
chore: bump aida-core to v1.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,10 +12,10 @@
       "source": {
         "source": "github",
         "repo": "oakensoul/aida-core-plugin",
-        "ref": "v1.1.1"
+        "ref": "v1.1.2"
       },
       "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "category": "core",
       "homepage": "https://github.com/oakensoul/aida-core-plugin",
       "author": {


### PR DESCRIPTION
## Summary
- Bump aida-core plugin from v1.1.1 to v1.1.2
- Includes fixes for generated SKILL.md markdown linting and install.py bootstrap

## Test plan
- [ ] CI passes
- [ ] Plugin install resolves to v1.1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)