### PR TITLE
ci: enforce no-AI-coauthor policy in PR commits

### DIFF
--- a/.github/workflows/no-ai-coauthor.yml
+++ b/.github/workflows/no-ai-coauthor.yml
@@ -1,0 +1,46 @@
+---
+name: No AI Co-Authors
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  no-ai-coauthors:
+    name: No AI Co-Authors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan PR commits for AI co-author trailers
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+
+          # Collect commit messages unique to this PR
+          msgs=$(git log --format='%H%n%B%n---END---' "origin/$BASE_REF..HEAD")
+
+          # Match Co-Authored-By trailers attributing authorship to known AI
+          # assistants or to Anthropic / OpenAI noreply addresses.
+          pattern='^[Cc]o-[Aa]uthored-[Bb]y:.*([Cc]laude|[Cc]opilot'
+          pattern="$pattern|[Cc]ursor|[Cc]hat[Gg][Pp][Tt]|[Gg]emini"
+          pattern="$pattern|[Aa]ider|[Cc]odex|[Tt]abnine"
+          pattern="$pattern|noreply@(anthropic|openai)\\.com)"
+
+          if echo "$msgs" | grep -E "$pattern" > /tmp/ai-coauthors; then
+            echo "::error::AI co-author trailers detected in PR commits:"
+            echo ""
+            cat /tmp/ai-coauthors
+            echo ""
+            err="AI co-author attribution is not allowed in this org."
+            err="$err See CONTRIBUTING.md."
+            err="$err Fix: amend or rebase to drop the Co-Authored-By trailer,"
+            err="$err then force-push your branch."
+            echo "::error::$err"
+            exit 1
+          fi
+
+          echo "No AI co-author trailers detected."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## [Unreleased]
 
+### Added
+
+- CI workflow `no-ai-coauthor.yml` that fails any PR whose commits contain
+  `Co-Authored-By:` trailers attributing authorship to known AI tools
+  (Claude, Copilot, Cursor, ChatGPT, Gemini, Aider, Codex, Tabnine) or
+  to Anthropic / OpenAI noreply addresses. There is no skip label.
+
 ### Changed
 
 - Bumped `aida-core` plugin pin from v1.4.2 to v1.4.5.
+- Stripped pre-existing AI co-author trailers from `main` history via
+  `git filter-branch` (force-pushed). The trailers were on 7 historical
+  commits and have been removed; commit subjects and content are
+  unchanged. New commit SHAs as a result — anyone with a local clone
+  should `git fetch && git reset --hard origin/main`.
 
 ## [0.1.0] - 2026-04-28
 


### PR DESCRIPTION
## Summary

Closes the loop on the no-AI-coauthorship convention. Two parts:

1. **New CI workflow** `.github/workflows/no-ai-coauthor.yml` that scans the unique commits of every pull request against `main` and fails if any `Co-Authored-By:` trailer attributes authorship to a known AI tool (Claude, Copilot, Cursor, ChatGPT, Gemini, Aider, Codex, Tabnine) or to an Anthropic / OpenAI noreply address. **No skip label.** The policy is absolute.
2. **CHANGELOG entry** under `[Unreleased]` documenting both the new check and the prior history-rewrite that stripped 7 historical AI co-author trailers from `main` (force-pushed earlier today).

Closes #22.

## Why

The org's commit conventions (in the private handbook) declare AI co-author attribution out of bounds — `Co-Authored-By:` is a claim that another *person* shares responsibility for the change, which doesn't apply to AI tools. Without an enforcement check, this drifts the moment anyone forgets. CI is the right place for it.

## How a contributor fixes a flagged PR

The CI annotation tells them: amend or rebase the offending commit(s) to drop the trailer, force-push the branch, the check re-runs.

## Test plan

- [x] YAML parses cleanly (`js-yaml` load succeeds)
- [x] No lines exceed yamllint's 120-char limit
- [x] `markdownlint-cli2 CHANGELOG.md` passes
- [x] This PR's own commits don't trigger the check (the `No AI Co-Authors` job is green on this PR — self-validating)
- [ ] After merge: a follow-up PR introducing a test commit with a real `Co-Authored-By: Claude` trailer fails this job (sanity check, can be done by anyone)

## Notes

If a real human contributor named "Claude" or working at `openai.com` ever opens a PR, the check could false-positive. Edge case; handled per-PR by amending the trailer to use a different (or no) attribution. The pattern errs on the side of the org policy, intentionally.