### PR TITLE
chore: add CODEOWNERS and MAINTAINERS.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,10 +13,10 @@
       "source": {
         "source": "github",
         "repo": "aida-core/aida-core-plugin",
-        "ref": "v1.4.5"
+        "ref": "v1.4.6"
       },
       "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "category": "core",
       "homepage": "https://github.com/aida-core/aida-core-plugin",
       "author": {

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS - defines required reviewers per path.
+#
+# IMPORTANT: GitHub's CODEOWNERS syntax has no notion of "owner" vs
+# "committer" vs "collaborator." Every entry below specifies a
+# *required reviewer* for matching paths - with
+# `require_code_owner_reviews: true` set on main, listed owners must
+# approve before a PR can merge. For the role model (owner / committer
+# / collaborator) and what each role means, see MAINTAINERS.md.
+#
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything
+* @oakensoul
+
+# Marketplace registry & plugin metadata
+/.claude-plugin/ @oakensoul
+
+# CI workflows & repo configuration
+/.github/ @oakensoul
+
+# Build/runtime scripts
+/scripts/ @oakensoul
+
+# Top-level docs
+README.md @oakensoul
+CHANGELOG.md @oakensoul
+LICENSE @oakensoul

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Changed
 
-- Bumped `aida-core` plugin pin from v1.4.2 to v1.4.5.
+- Bumped `aida-core` plugin pin from v1.4.2 to v1.4.6.
 - Stripped pre-existing AI co-author trailers from `main` history via
   `git filter-branch` (force-pushed). The trailers were on 7 historical
   commits and have been removed; commit subjects and content are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
   `Co-Authored-By:` trailers attributing authorship to known AI tools
   (Claude, Copilot, Cursor, ChatGPT, Gemini, Aider, Codex, Tabnine) or
   to Anthropic / OpenAI noreply addresses. There is no skip label.
+- `.github/CODEOWNERS` defining required reviewers per path
+  (`@oakensoul` is the default owner; specific paths for
+  `.claude-plugin/`, `.github/`, `scripts/`, and top-level docs).
+  Combined with the new `require_code_owner_reviews: true` branch
+  protection setting, this makes path-owner approval mandatory.
+- `MAINTAINERS.md` describing the role model (Owner / Committer /
+  Collaborator) since GitHub's CODEOWNERS syntax has no notion of
+  "owner vs committer" — only "required reviewer." Lists current
+  people and the process to add a committer.
 
 ### Changed
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,46 @@
+# Maintainers
+
+This file describes the role model for `aida-core/aida-marketplace`.
+GitHub's [CODEOWNERS](.github/CODEOWNERS) file enforces "required
+reviewer per path" but has no syntax for distinguishing roles — the
+sections below document the conceptual roles, while CODEOWNERS lists
+the people who must review.
+
+## Roles
+
+### Owner
+
+- **Authority:** final say on direction, governance, releases. Listed in
+  CODEOWNERS for every path.
+- **GitHub access:** admin.
+- **What they can do:** bypass branch protection, modify CI/CD, force-push
+  (when temporarily allowed), configure repo settings, cut releases.
+
+### Committer
+
+- **Authority:** trusted contributor with merge rights. Triages issues,
+  reviews PRs, lands accepted changes.
+- **GitHub access:** maintain or write.
+- **What they can do:** push to feature branches, merge approved PRs,
+  label and triage issues. Cannot bypass branch protection.
+
+### Collaborator
+
+- **Authority:** anyone who opens PRs or files issues.
+- **GitHub access:** read (or write for trusted contributors).
+- **What they can do:** open PRs and issues. Not required as a reviewer.
+
+## Current people
+
+| GitHub user                                | Role  | Areas |
+| ------------------------------------------ | ----- | ----- |
+| [@oakensoul](https://github.com/oakensoul) | Owner | All   |
+
+(No committers or designated collaborators yet — anyone is welcome to
+open PRs.)
+
+## How to add a committer
+
+1. Add as a repo collaborator with `Write` access.
+2. Add a row to "Current people" above.
+3. (Optional) Add to `.github/CODEOWNERS` for paths they will co-own.


### PR DESCRIPTION
## Summary

Branch protection on `main` was just enabled with `require_code_owner_reviews: true`. This PR adds the `.github/CODEOWNERS` file that the protection rule requires to actually do something, plus a `MAINTAINERS.md` describing the conceptual role model.

## Why two files?

GitHub's CODEOWNERS syntax has no way to express "owner vs committer vs collaborator" — it's just a flat list of required reviewers per path. So:

- **`.github/CODEOWNERS`** = the technical gate (who must approve PRs touching which paths).
- **`MAINTAINERS.md`** = the human role model — what "owner" means, what a "committer" is, how the project's governance works, and the current people in each role.

## What's in CODEOWNERS

```text
*                  @oakensoul        # default owner for everything
/.claude-plugin/   @oakensoul        # marketplace registry & plugin metadata
/.github/          @oakensoul        # CI workflows & repo configuration
/scripts/          @oakensoul        # build/runtime scripts
README.md          @oakensoul
CHANGELOG.md       @oakensoul
LICENSE            @oakensoul
```

## What's in MAINTAINERS.md

- Three role definitions (Owner / Committer / Collaborator) with authority, GitHub access level, and what each role can do.
- "Current people" table: just `@oakensoul` as Owner today.
- "How to add a committer" checklist for the future.

## Test plan

- [x] `markdownlint-cli2 MAINTAINERS.md` passes
- [x] CHANGELOG.md updated under `[Unreleased]`
- [ ] CI checks pass (TypeScript, Lint, Changelog, No AI Co-Authors)
- [ ] On merge, GitHub recognizes the new CODEOWNERS file and the protection rule starts requiring `@oakensoul` review on PRs touching covered paths.