### PR TITLE
release: v0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "aida",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AIDA - Agentic Intelligence Digital Assistant. Foundation plugins for extending Claude Code.",
   "owner": {
     "name": "oakensoul",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-28
+
+Governance, policy, and a new aida-core pin. Adds branch-protection
+support files (CODEOWNERS, MAINTAINERS.md) and an AI-attribution gate
+in CI; bumps the aida-core plugin pin to v1.4.6.
+
 ### Added
 
 - CI workflow `no-ai-coauthor.yml` that fails any PR whose commits contain
@@ -26,6 +32,7 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 ### Changed
 
 - Bumped `aida-core` plugin pin from v1.4.2 to v1.4.6.
+- Top-level `version` field in `marketplace.json` bumped to `0.2.0`.
 - Stripped pre-existing AI co-author trailers from `main` history via
   `git filter-branch` (force-pushed). The trailers were on 7 historical
   commits and have been removed; commit subjects and content are


### PR DESCRIPTION
## Summary

Promotes the accumulated `[Unreleased]` entries to **`[0.2.0] - 2026-04-28`** and bumps the top-level marketplace `version` field in `marketplace.json` from `0.1.0` to `0.2.0`.

## What's in v0.2.0

### Added

- `.github/CODEOWNERS` (#33)
- `MAINTAINERS.md` describing the Owner / Committer / Collaborator role model (#33)
- `no-ai-coauthor.yml` CI workflow blocking AI co-authorship trailers on PRs (#31)

### Changed

- `aida-core` plugin pin: v1.4.2 → v1.4.6 (covers PRs #32 + #33)
- Top-level `marketplace.json` version: 0.1.0 → 0.2.0
- AI co-author trailers stripped from main history (`git filter-branch`, force-pushed earlier today)

## Test plan

- [x] `npm run check` confirms aida-core pin is up to date
- [x] `markdownlint-cli2 CHANGELOG.md` clean
- [ ] CI checks pass (TypeScript, Lint, Changelog, No AI Co-Authors)
- [ ] After merge: tag `v0.2.0` at the merge commit + create GitHub release with these notes