### PR TITLE
ci: prune stale automation branches before opening new update PR

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -69,6 +69,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Prune stale automation branches before creating a new one.
+          # Safe: the open-PR check above already exited if any active PR exists,
+          # so anything still matching the prefix has a closed/merged/no PR.
+          STALE=$(git ls-remote --heads origin 'automated/plugin-updates-*' \
+            | awk '{print $2}' | sed 's|refs/heads/||')
+          if [ -n "$STALE" ]; then
+            echo "Pruning stale automation branches:"
+            echo "$STALE"
+            echo "$STALE" | xargs git push origin --delete
+          fi
+
           BRANCH="automated/plugin-updates-$(date +%Y%m%d-%H%M)"
           git checkout -b "$BRANCH"
           git commit -m "chore: update plugin versions" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## [Unreleased]
 
+### Changed
+
+- `check-updates.yml` workflow now prunes prior `automated/plugin-updates-*`
+  branches before opening a new update PR, so closed/superseded automation
+  branches no longer accumulate on origin.
+
 ## [0.2.0] - 2026-04-28
 
 Governance, policy, and a new aida-core pin. Adds branch-protection


### PR DESCRIPTION
## Summary

- The weekly `check-updates` workflow created a new `automated/plugin-updates-*` branch each Monday but never cleaned up prior ones, so closed/superseded automation branches accumulated on origin (just nuked seven of them manually).
- Adds a prune step that lists remote branches matching the prefix and deletes them before creating the new branch.
- Runs only after the existing open-PR check has exited early on active PRs, so anything still matching the prefix is provably stale (no PR, or a closed/merged PR).

## Test plan

- [ ] Workflow YAML lints clean (yamllint, 120-char limit)
- [ ] On the next scheduled run with no open update PRs, verify any pre-existing `automated/plugin-updates-*` branches are deleted before the new one is pushed
- [ ] On a run that finds an existing open PR, verify it still short-circuits before reaching the prune step (no branches deleted)
- [ ] On a run that finds no version changes, verify it short-circuits before the prune step