### PR TITLE
chore: add AUTHORS file at repo root

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,15 @@
+# AUTHORS
+
+This file lists substantive contributors to aida-marketplace.
+
+The collective copyright holder is "The AIDA Marketplace Authors" (as
+referenced in SPDX `SPDX-FileCopyrightText` headers throughout the
+repo). The roster below is the authoritative list of who that
+collective is.
+
+Substantive contributors are added on first merged PR. Order is by
+first contribution.
+
+## Contributors
+
+- Rob Johnson <github@oakensoul.com> (@oakensoul) — maintainer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## [Unreleased]
 
+### Added
+
+- `AUTHORS` file at the repo root listing substantive contributors.
+  The collective copyright holder used in SPDX file headers is
+  "The AIDA Marketplace Authors"; the AUTHORS roster is the
+  authoritative list of who that collective is. Lets file headers
+  stay stable as the contributor list grows — new substantive
+  contributors are appended on first merged PR.
+
 ### Changed
 
 - `check-updates.yml` workflow now prunes prior `automated/plugin-updates-*`


### PR DESCRIPTION
## Summary

Adds `AUTHORS` at the repo root listing substantive contributors to
aida-marketplace. The collective copyright holder used in SPDX
`SPDX-FileCopyrightText` headers is "The AIDA Marketplace Authors";
the AUTHORS roster is the authoritative list of who that collective
is. This lets file headers stay stable as the contributor list
grows — substantive contributors are appended on first merged PR
rather than touching every header in the repo.

Roster seeded from `git shortlog -sne` on this repo's history.
Ordered by first contribution.

Mirrors the AUTHORS pattern landed in
[aida-core/aida-core-plugin#75](https://github.com/aida-core/aida-core-plugin/pull/75)
ahead of the SPDX header rollout. The bulk-SPDX-headers PR will
land separately on top of this one.

## Test plan

- [ ] CI green (no AI co-authors, changelog updated, lint passes)
- [ ] Roster matches `git shortlog -sne`