### PR TITLE
chore: adopt SPDX file headers and REUSE compliance

### DIFF
--- a/.claude/aida-project-context.yml
+++ b/.claude/aida-project-context.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
 version: 0.7.0
 last_updated: '2026-03-18T19:23:07.105782+00:00'
 config_complete: true

--- a/.claude/skills/project-context/SKILL.md
+++ b/.claude/skills/project-context/SKILL.md
@@ -11,6 +11,9 @@ tags:
   - configuration
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Project Context: aida-marketplace
 
 This skill provides factual information about aida-marketplace's

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
 # CODEOWNERS - defines required reviewers per path.
 #
 # IMPORTANT: GitHub's CODEOWNERS syntax has no notion of "owner" vs

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 name: Check Plugin Updates
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 name: CI
 
@@ -45,19 +48,22 @@ jobs:
 
       - name: Install linters
         run: |
-          pip install yamllint
+          pip install -r requirements-dev.txt
           npm install -g markdownlint-cli2
 
       - name: Lint YAML
-        run: yamllint .github/workflows/ .yamllint.yml .markdownlint.yml
+        run: make lint-yaml
 
       - name: Lint Markdown
-        run: markdownlint-cli2 '**/*.md'
+        run: make lint-md
 
       - name: Validate JSON
         run: |
-          python -m json.tool .claude-plugin/marketplace.json > /dev/null
+          make lint-json
           echo "marketplace.json is valid JSON"
+
+      - name: Lint REUSE / SPDX
+        run: make lint-reuse
 
   changelog:
     name: Changelog

--- a/.github/workflows/no-ai-coauthor.yml
+++ b/.github/workflows/no-ai-coauthor.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 name: No AI Co-Authors
 

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 # Markdownlint Configuration
 

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 # YAML Lint Configuration
 # https://yamllint.readthedocs.io/

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,15 @@
+# AUTHORS
+
+This file lists substantive contributors to aida-marketplace.
+
+The collective copyright holder is "The AIDA Marketplace Authors" (as
+referenced in SPDX `SPDX-FileCopyrightText` headers throughout the
+repo). The roster below is the authoritative list of who that
+collective is.
+
+Substantive contributors are added on first merged PR. Order is by
+first contribution.
+
+## Contributors
+
+- Rob Johnson <github@oakensoul.com> (@oakensoul) — maintainer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## [Unreleased]
 
+### Added
+
+- `AUTHORS` file at the repo root listing substantive contributors.
+  The collective copyright holder used in SPDX file headers is
+  "The AIDA Marketplace Authors"; the AUTHORS roster is the
+  authoritative list of who that collective is. Lets file headers
+  stay stable as the contributor list grows — new substantive
+  contributors are appended on first merged PR.
+
 ### Changed
 
 - `check-updates.yml` workflow now prunes prior `automated/plugin-updates-*`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Changelog
 
 All notable changes to the AIDA marketplace are documented in this file.
@@ -15,9 +18,28 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
   authoritative list of who that collective is. Lets file headers
   stay stable as the contributor list grows — new substantive
   contributors are appended on first merged PR.
+- SPDX `SPDX-FileCopyrightText` / `SPDX-License-Identifier` headers
+  on every hand-authored source file (Markdown, YAML, TOML,
+  CODEOWNERS, TypeScript, Makefile, requirements). Inserted via the
+  new `scripts/add_spdx_headers.py` — idempotent, dry-run by
+  default, reads `git ls-files` and skips fixtures, JSON, lockfiles,
+  and `LICENSE` itself per the org skip list.
+- `REUSE.toml` at the repo root licensing the skip categories
+  (JSON files, `AUTHORS`, `.gitignore`, `.markdownlintignore`,
+  `.gitkeep`). Repo is REUSE 3.3 compliant.
+- `LICENSES/MPL-2.0.txt` (REUSE-required canonical license text).
+  `LICENSE` at root is unchanged so GitHub still displays it.
+- `Makefile` exposing `lint-yaml`, `lint-md`, `lint-json`,
+  `lint-reuse`, and an aggregate `lint` target. Mirrors the
+  pattern used in `aida-core/aida-core-plugin`.
+- `requirements-dev.txt` pinning `yamllint>=1.35` and
+  `reuse>=4.0` for local + CI use.
 
 ### Changed
 
+- CI `lint` job now runs `make lint-yaml` / `make lint-md` /
+  `make lint-json` / `make lint-reuse`. `reuse lint` is now a
+  blocking gate for SPDX/REUSE compliance.
 - `check-updates.yml` workflow now prunes prior `automated/plugin-updates-*`
   branches before opening a new update PR, so closed/superseded automation
   branches no longer accumulate on origin.

--- a/LICENSES/MPL-2.0.txt
+++ b/LICENSES/MPL-2.0.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Maintainers
 
 This file describes the role model for `aida-core/aida-marketplace`.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
+# AIDA Marketplace Makefile
+# Run `make help` for available targets
+
+.PHONY: help install lint lint-yaml lint-md lint-json lint-reuse typecheck check
+
+help: ## Show this help message
+	@echo "AIDA Marketplace - Available targets:"
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+
+# Dependencies
+install: ## Install Node and Python dev dependencies
+	npm ci
+	pip install -r requirements-dev.txt
+
+# Linting
+lint: lint-yaml lint-md lint-json lint-reuse ## Run all linters (YAML, Markdown, JSON, REUSE)
+
+lint-yaml: ## Run yamllint on YAML files
+	yamllint .github/workflows/ .yamllint.yml .markdownlint.yml
+
+lint-md: ## Run markdownlint-cli2 on Markdown files
+	markdownlint-cli2 '**/*.md'
+
+lint-json: ## Validate marketplace.json
+	python3 -m json.tool .claude-plugin/marketplace.json > /dev/null
+
+lint-reuse: ## Verify REUSE / SPDX compliance (every file has copyright + license info)
+	reuse lint
+
+# Typecheck + plugin validation (mirrors the CI typecheck job)
+typecheck: ## Run TypeScript typecheck
+	npm run typecheck
+
+check: ## Run plugin version check
+	npm run check

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Marketplace
 
 Plugin marketplace for AIDA — Agentic Intelligence Digital Assistant.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,22 @@
+version = 1
+SPDX-PackageName = "aida-marketplace"
+SPDX-PackageSupplier = "oakensoul <github@oakensoul.com>"
+SPDX-PackageDownloadLocation = "https://github.com/aida-core/aida-marketplace"
+SPDX-PackageComment = "Copyright is held by 'The AIDA Marketplace Authors'; the roster lives in the AUTHORS file at the repo root. This file licenses paths that cannot carry inline SPDX headers (no comment syntax) or that should not carry one. Files that can carry inline headers should — see scripts/add_spdx_headers.py."
+
+# JSON has no comment syntax, so it cannot carry an inline SPDX header.
+[[annotations]]
+path = "**.json"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 The AIDA Marketplace Authors"
+SPDX-License-Identifier = "MPL-2.0"
+
+# Top-level config files and AUTHORS roster — AUTHORS' contents
+# already provide attribution (it lists the contributors), so
+# inline SPDX would be redundant. .markdownlintignore is a single-line
+# ignore file; an inline header would dwarf the content.
+[[annotations]]
+path = ["AUTHORS", ".gitignore", "**/.gitignore", "**/.gitkeep", ".markdownlintignore"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 The AIDA Marketplace Authors"
+SPDX-License-Identifier = "MPL-2.0"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
+# AIDA Marketplace Development Dependencies
+#
+# Install with: make install (or pip install -r requirements-dev.txt)
+
+# Linting
+yamllint>=1.35
+reuse>=4.0

--- a/scripts/add_spdx_headers.py
+++ b/scripts/add_spdx_headers.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+"""Add SPDX-FileCopyrightText/SPDX-License-Identifier headers to source files.
+
+Idempotent: files that already contain ``SPDX-License-Identifier`` are skipped.
+Operates on tracked files only (``git ls-files``) and respects a built-in
+skip list for fixtures, JSON, lockfiles, generated artifacts, and
+scaffolding templates (those are covered by ``.reuse/dep5`` instead).
+
+Run from repo root::
+
+    python3 scripts/add_spdx_headers.py        # dry-run; prints planned changes
+    python3 scripts/add_spdx_headers.py --apply # actually write changes
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+COPYRIGHT_HOLDER = "The AIDA Marketplace Authors"
+LICENSE_ID = "MPL-2.0"
+YEAR = "2026"
+
+# Substrings that indicate a header is already present.
+SENTINEL = "SPDX-License-Identifier"
+
+# Skip rules per CONTRIBUTING.md#licensing. We match by explicit
+# basename / suffix / path-prefix checks rather than glob patterns
+# because fnmatch's `*` matches `/` (so `*.json` and `**/*.json`
+# behave identically) and PurePath.match only learned proper `**`
+# semantics in Python 3.13. Explicit logic is cheaper than a custom
+# globber and clearer than relying on either quirk.
+_SKIP_BASENAMES: frozenset[str] = frozenset({
+    "LICENSE",
+    "AUTHORS",
+    ".gitignore",
+    ".gitkeep",
+})
+_SKIP_SUFFIXES: tuple[str, ...] = (
+    ".json",            # No comment syntax
+    ".json.template",   # JSON template — same constraint
+    ".jinja2",          # Scaffolding templates; REUSE.toml covers
+    ".template",        # Scaffolding templates; REUSE.toml covers
+)
+
+
+@dataclass(frozen=True)
+class CommentStyle:
+    line_prefix: str          # what each header line starts with
+    line_suffix: str = ""     # what each header line ends with
+    blank_line: str = ""      # blank line representation (with suffix if needed)
+
+
+HASH = CommentStyle(line_prefix="# ")
+HTML = CommentStyle(line_prefix="<!-- ", line_suffix=" -->")
+SLASH = CommentStyle(line_prefix="// ")
+
+
+def comment_style_for(path: Path) -> CommentStyle | None:
+    """Return the comment style for a path, or None if it should be skipped.
+
+    Caller must already have applied ``should_skip`` to honor the
+    repo's skip list.
+    """
+    name = path.name
+    suffix = path.suffix.lower()
+
+    if suffix == ".md":
+        return HTML
+    if suffix in {".py", ".sh", ".yml", ".yaml", ".toml"}:
+        return HASH
+    if suffix in {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"}:
+        return SLASH
+    if suffix == ".txt" and name.startswith("requirements"):
+        return HASH
+    if name in {"Makefile", "Dockerfile"} or name.startswith("Makefile."):
+        return HASH
+    if path.as_posix().endswith(".github/CODEOWNERS"):
+        return HASH
+    return None
+
+
+def should_skip(rel_path: str) -> bool:
+    """Return True if this tracked file should not get an inline SPDX header.
+
+    REUSE.toml is responsible for licensing the skipped paths.
+    """
+    p = PurePosixPath(rel_path)
+    name = p.name
+
+    if name in _SKIP_BASENAMES:
+        return True
+    if any(name.endswith(suffix) for suffix in _SKIP_SUFFIXES):
+        return True
+
+    parts = p.parts
+    # LICENSES/<id>.txt — REUSE-required canonical license texts
+    if len(parts) >= 1 and parts[0] == "LICENSES":
+        return True
+    # tests/fixtures/** — fixture trees
+    if len(parts) >= 2 and parts[0] == "tests" and parts[1] == "fixtures":
+        return True
+    # tests/integration/<lang>/sample-project/** — fixtures simulating
+    # downstream user projects
+    if (
+        len(parts) >= 4
+        and parts[0] == "tests"
+        and parts[1] == "integration"
+        and parts[3] == "sample-project"
+    ):
+        return True
+
+    return False
+
+
+def render_header(style: CommentStyle) -> list[str]:
+    # REUSE-IgnoreStart
+    return [
+        f"{style.line_prefix}SPDX-FileCopyrightText: {YEAR} {COPYRIGHT_HOLDER}{style.line_suffix}",
+        f"{style.line_prefix}SPDX-License-Identifier: {LICENSE_ID}{style.line_suffix}",
+    ]
+    # REUSE-IgnoreEnd
+
+
+def find_insertion_point(lines: list[str], style: CommentStyle) -> int:
+    """Return the line index at which the header should be inserted.
+
+    For HASH style, skip a leading shebang. For HTML style (markdown), skip a
+    leading YAML frontmatter block delimited by ``---`` on the first line.
+    """
+    if not lines:
+        return 0
+
+    if style is HASH and lines[0].startswith("#!"):
+        return 1
+
+    if style is HTML and lines[0].rstrip() == "---":
+        # Find the closing --- of frontmatter
+        for idx in range(1, len(lines)):
+            if lines[idx].rstrip() == "---":
+                return idx + 1
+        # Malformed frontmatter (no close): bail to top
+        return 0
+
+    return 0
+
+
+def insert_header(lines: list[str], style: CommentStyle) -> list[str]:
+    """Return new file lines with the SPDX header inserted at the right spot."""
+    insertion = find_insertion_point(lines, style)
+    header = render_header(style)
+
+    # Build the inserted block: blank line if needed before header, then
+    # header lines, then blank line before the rest of the content.
+    block: list[str] = []
+
+    needs_leading_blank = (
+        insertion > 0 and lines[insertion - 1].strip() != ""
+    )
+    if needs_leading_blank:
+        block.append("")
+
+    block.extend(header)
+
+    if insertion < len(lines) and lines[insertion].strip() != "":
+        block.append("")
+
+    return lines[:insertion] + block + lines[insertion:]
+
+
+def already_has_header(text: str) -> bool:
+    return SENTINEL in text
+
+
+def tracked_files() -> list[str]:
+    out = subprocess.check_output(["git", "ls-files"], text=True)
+    return [line for line in out.splitlines() if line]
+
+
+def process(repo_root: Path, apply: bool) -> int:
+    changed: list[str] = []
+    skipped_no_style: list[str] = []
+    skipped_pattern: list[str] = []
+    already: list[str] = []
+
+    for rel in tracked_files():
+        if should_skip(rel):
+            skipped_pattern.append(rel)
+            continue
+        path = repo_root / rel
+        if not path.is_file():
+            continue
+        style = comment_style_for(path)
+        if style is None:
+            skipped_no_style.append(rel)
+            continue
+        text = path.read_text(encoding="utf-8")
+        if already_has_header(text):
+            already.append(rel)
+            continue
+
+        # Preserve final newline status by working with split lines.
+        ends_with_newline = text.endswith("\n")
+        lines = text.split("\n")
+        if ends_with_newline:
+            # split leaves a trailing empty string for the final newline; drop it
+            lines = lines[:-1]
+
+        new_lines = insert_header(lines, style)
+        new_text = "\n".join(new_lines) + ("\n" if ends_with_newline else "")
+
+        if apply:
+            path.write_text(new_text, encoding="utf-8")
+        changed.append(rel)
+
+    print(f"Files that would be updated: {len(changed)}")
+    for rel in changed:
+        print(f"  + {rel}")
+    print(f"Already had headers: {len(already)}")
+    print(f"Skipped (no comment style for type): {len(skipped_no_style)}")
+    print(f"Skipped (matches skip pattern): {len(skipped_pattern)}")
+    if not apply:
+        print("\nDry run — re-run with --apply to write changes.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true",
+                        help="actually write changes (default: dry run)")
+    args = parser.parse_args()
+    repo_root = Path(__file__).resolve().parent.parent
+    return process(repo_root, apply=args.apply)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update-marketplace.ts
+++ b/scripts/update-marketplace.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+// SPDX-License-Identifier: MPL-2.0
+
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";


### PR DESCRIPTION
## Summary

Adopts SPDX file headers and REUSE 3.3 compliance, mirroring the
pattern landed in
[aida-core/aida-core-plugin#76](https://github.com/aida-core/aida-core-plugin/pull/76).

- SPDX-FileCopyrightText / SPDX-License-Identifier MPL-2.0 headers
  on every hand-authored source file (Markdown, YAML, TOML,
  CODEOWNERS, TypeScript, Makefile, requirements.txt). Inserted via
  the new `scripts/add_spdx_headers.py` — idempotent, dry-run by
  default, reads `git ls-files` and skips fixtures, JSON, lockfiles,
  and `LICENSE` itself per the org skip list.
- `REUSE.toml` at repo root licenses the skip categories (JSON,
  AUTHORS, .gitignore, .markdownlintignore, .gitkeep). 22/22 files
  REUSE-compliant.
- `LICENSES/MPL-2.0.txt` (REUSE-required canonical license text).
  `LICENSE` at root unchanged so GitHub still displays it.
- `Makefile` exposing `lint-yaml` / `lint-md` / `lint-json` /
  `lint-reuse` / aggregate `lint`. `requirements-dev.txt` pinning
  `yamllint` and `reuse>=4.0`. CI's lint job now shells out to
  those make targets and adds `make lint-reuse` as a blocking gate.

Stacked on #38 (AUTHORS). Will retarget to `main` once #38 merges.

## Divergences from aida-core-plugin

- `add_spdx_headers.py` adds a `SLASH` comment style (`// `) to
  cover `.ts` / `.js` / `.tsx` / `.mjs` / `.cjs`, since this repo
  has TypeScript source (`scripts/update-marketplace.ts`) that
  aida-core-plugin doesn't. `COPYRIGHT_HOLDER` is
  `"The AIDA Marketplace Authors"`.
- `REUSE.toml` adds `.markdownlintignore` to the bare-config-file
  skip list (single-line file; an inline header would dwarf the
  content). Drops the scaffolding-templates and integration-fixtures
  sections — this repo has neither.
- No Python source / no `lint-py` / no `lint-frontmatter` targets.
  Makefile is correspondingly smaller than aida-core-plugin's.

## Test plan

- [ ] CI green: typecheck + lint (yaml/md/json/reuse) + changelog +
      no-AI-coauthor jobs all pass
- [ ] `reuse lint` shows 22/22 files compliant locally
- [ ] `npm run typecheck` clean (TypeScript `// SPDX-...` headers
      don't break compilation)
- [ ] Spot-check that headers landed correctly: `.ts` uses `// `,
      `.md` uses `<!-- ... -->` after frontmatter, `.yml` uses
      `# ` before the `---` document marker

## Out of scope

Scaffolding-emits-headers changes (mirroring aida-core-plugin#79
and #80) are not included — `aida-marketplace` doesn't currently
ship tooling that generates files for downstream users.