### PR TITLE
docs: ADR-driven governance — five Phase 1 decisions accepted

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,13 +3,12 @@
   "version": "0.2.0",
   "description": "AIDA - Agentic Intelligence Digital Assistant. Foundation plugins for extending Claude Code.",
   "owner": {
-    "name": "oakensoul",
-    "email": "oakensoul@users.noreply.github.com",
-    "url": "https://github.com/oakensoul"
+    "name": "oakensoul"
   },
   "plugins": [
     {
       "name": "aida-core",
+      "kind": "plugin",
       "source": {
         "source": "github",
         "repo": "aida-core/aida-core-plugin",
@@ -20,8 +19,7 @@
       "category": "core",
       "homepage": "https://github.com/aida-core/aida-core-plugin",
       "author": {
-        "name": "oakensoul",
-        "email": "oakensoul@users.noreply.github.com"
+        "name": "aida-core"
       },
       "tags": [
         "core",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- `docs/adr/` directory adopting ADR-driven governance for the
+  marketplace (umbrella #42). Five Phase 1 ADRs accepted from the
+  /discuss issues filed in May:
+  - ADR-0001: validator implementation language → TypeScript (#57)
+  - ADR-0002: marketplace operator profiles → Simple / Enterprise
+    (#56); aida-marketplace adopts Simple
+  - ADR-0003: entry kinds → `plugin` / `guidebook` with dual
+    enforcement (schema field + matching repo suffix, validator
+    checks both agree) (#55)
+  - ADR-0004: GitHub App → profile-conditional (Simple is App-less,
+    Enterprise requires one) (#58)
+  - ADR-0005: author and owner identity → GitHub slugs everywhere,
+    no email, no owner.url; operator chooses personal vs org slug
+    for `owner.name` (#59)
+- `docs/profiles/renovate-simple.json` — reference Renovate config
+  for Simple-profile marketplaces. Auto-merges trusted-source
+  minor/patch updates behind CI; gates external sources and major
+  bumps on dashboard approval.
+- `docs/profiles/renovate-enterprise.json` — reference Renovate
+  config for Enterprise-profile marketplaces. Conservative defaults
+  (`automerge: false`) with dashboard approval for non-trusted
+  sources and major bumps.
 - `AUTHORS` file at the repo root listing substantive contributors.
   The collective copyright holder used in SPDX file headers is
   "The AIDA Marketplace Authors"; the AUTHORS roster is the
@@ -37,6 +59,12 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Changed
 
+- `.claude-plugin/marketplace.json` migrated to comply with ADR-0003
+  and ADR-0005: added `kind: "plugin"` to the aida-core entry;
+  changed the per-plugin `author` to `{ "name": "aida-core" }`
+  (org slug, no email); slimmed top-level `owner` to
+  `{ "name": "oakensoul" }` (no email, no url — operator choice
+  to retain personal handle).
 - CI `lint` job now runs `make lint-yaml` / `make lint-md` /
   `make lint-json` / `make lint-reuse`. `reuse lint` is now a
   blocking gate for SPDX/REUSE compliance.

--- a/docs/adr/0000-adr-template.md
+++ b/docs/adr/0000-adr-template.md
@@ -1,0 +1,43 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-NNNN: Short noun phrase describing the decision
+
+- **Status:** Proposed
+- **Date:** YYYY-MM-DD
+- **Filed from:** #issue-number (if applicable)
+
+## Context
+
+What is the problem? What forces are at play? Why is a decision needed now?
+
+Keep this section factual. State the situation, not the solution.
+
+## Considered options
+
+1. **Option A** — one-sentence description.
+2. **Option B** — one-sentence description.
+3. **Option C** — one-sentence description.
+
+For each, list pros and cons honestly. Don't strawman the rejected options.
+
+## Decision
+
+State the decision in one sentence. Then explain *why this option over the others*.
+
+If the decision is "do nothing yet" or "defer," say so explicitly and name the trigger that would reopen it.
+
+## Consequences
+
+What changes because of this decision? Include both the good (what we gain) and the costs (what we accept).
+
+## Enforcement
+
+How is this decision mechanically enforced so it doesn't drift?
+
+- Validator rule: …
+- CI workflow: …
+- Schema constraint: …
+- Documentation: …
+
+If enforcement is "human review only," say so — and consider whether that's enough.

--- a/docs/adr/0001-validator-language.md
+++ b/docs/adr/0001-validator-language.md
@@ -1,0 +1,62 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0001: Validator implementation language
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Filed from:** [#57](https://github.com/aida-core/aida-marketplace/issues/57)
+
+## Context
+
+The marketplace needs a validator that enforces per-rule constraints on `marketplace.json` and listed-plugin metadata (see [#42](https://github.com/aida-core/aida-marketplace/issues/42)). Today, validation lives in TypeScript inside `scripts/update-marketplace.ts --check`. A downstream marketplace (Splash-AI) implements the same checks as `scripts/validate-marketplace.sh` calling Python heredocs.
+
+We need to decide on a canonical implementation language so that:
+
+1. New rules land in a predictable place when ADRs are added.
+2. Downstream marketplaces have a reference pattern to copy.
+3. Contributors have one runtime to install when running validation locally.
+
+## Considered options
+
+1. **TypeScript (current)** — extend `scripts/update-marketplace.ts` with a structured `--check` mode that emits per-rule `OK` / `FAIL` / `SKIP` and names the ADR in failures.
+   - Pros: same language as update tooling, type safety, no second runtime, JSON Schema validators (ajv) are first-class.
+   - Cons: `npm install` required for any contributor running validation locally; bash composability is poor.
+
+2. **bash + Python (downstream pattern)** — a `validate-marketplace.sh` orchestrates per-rule sections, shelling out to `python3 -c '...'` for JSON manipulation.
+   - Pros: trivially scriptable per-rule, Python is ubiquitous on CI runners, easy to add a rule by appending a section.
+   - Cons: mixed runtime, brittle heredoc quoting, no shared type model with the update tooling.
+
+3. **Hybrid (bash orchestrator + TypeScript checker)** — keep the per-rule structure in bash, but each section calls into the TypeScript validator with a `--rule=<id>` flag.
+   - Pros: gets bash's per-rule visibility and TypeScript's type safety.
+   - Cons: most complex of the three; two languages to maintain; startup cost (Node) per rule invocation unless batched.
+
+## Decision
+
+Adopt **TypeScript** as the canonical validator language. Extend `scripts/update-marketplace.ts` into a `scripts/validate-marketplace.ts` (or add a `validate` subcommand) that emits structured per-rule results with ADR references in failure messages.
+
+Rationale:
+
+- The update tooling is already TypeScript — co-locating prevents the type model from forking.
+- `npm install` is a one-time cost; the marketplace already requires Node for update tooling.
+- JSON Schema validation (ADR-0xxx, see [#50](https://github.com/aida-core/aida-marketplace/issues/50)) is best expressed in JS-native validators.
+- Downstream marketplaces in mixed-runtime shops can still wrap our TS validator in bash; the reverse (wrapping bash from TS) is uglier.
+
+## Consequences
+
+**Gained:**
+
+- One language for both update tooling and validation; shared types for `marketplace.json`.
+- Easier to publish the validator as a reusable npm package later if needed.
+- Better tooling (LSP, refactors, generated types from JSON Schema).
+
+**Accepted costs:**
+
+- Contributors must run `npm install` to validate locally — partially mitigated by a `make validate` target that handles bootstrap.
+- Downstream marketplaces preferring Python/bash get a documented "alternative pattern" note but not first-class support.
+
+## Enforcement
+
+- The CI workflow runs `make validate` (which runs the TS validator); this is the gate.
+- New rules added per-ADR ship as a new check inside the validator, named with the ADR number (e.g., `[ADR-0003]`) so failure messages are traceable.
+- A future ADR may define the per-rule output format (`OK` / `FAIL` / `SKIP`) more rigorously — track as a follow-up if drift appears.

--- a/docs/adr/0001-validator-language.md
+++ b/docs/adr/0001-validator-language.md
@@ -9,7 +9,11 @@
 
 ## Context
 
-The marketplace needs a validator that enforces per-rule constraints on `marketplace.json` and listed-plugin metadata (see [#42](https://github.com/aida-core/aida-marketplace/issues/42)). Today, validation lives in TypeScript inside `scripts/update-marketplace.ts --check`. A downstream marketplace (Splash-AI) implements the same checks as `scripts/validate-marketplace.sh` calling Python heredocs.
+The marketplace needs a validator that enforces per-rule constraints on `marketplace.json` and
+listed-plugin metadata (see [#42](https://github.com/aida-core/aida-marketplace/issues/42)).
+Today, validation lives in TypeScript inside `scripts/update-marketplace.ts --check`. A
+downstream private marketplace implements the same checks as `scripts/validate-marketplace.sh`
+calling Python heredocs.
 
 We need to decide on a canonical implementation language so that:
 

--- a/docs/adr/0002-marketplace-profiles.md
+++ b/docs/adr/0002-marketplace-profiles.md
@@ -15,7 +15,10 @@ AIDA marketplaces vary widely in scope and constraints:
 - Others are private or internal, listing private plugins, with stricter review or compliance requirements.
 - Some are happy to run on hosted services; others have policy requirements to own the entire auth chain.
 
-A single recommended setup can't cover both ends well. Pushing complexity onto a hobby/community operator is wasteful; pushing under-engineered defaults onto a regulated operator is unsafe. Different ADRs (update mechanism, GitHub App, secret management) all bottom out at the same dimension: what kind of marketplace is this?
+A single recommended setup can't cover both ends well. Pushing complexity onto a
+hobby/community operator is wasteful; pushing under-engineered defaults onto a regulated
+operator is unsafe. Different ADRs (update mechanism, GitHub App, secret management) all
+bottom out at the same dimension: what kind of marketplace is this?
 
 This ADR defines two named operator profiles. Future ADRs and reference configs slot into one or the other.
 

--- a/docs/adr/0002-marketplace-profiles.md
+++ b/docs/adr/0002-marketplace-profiles.md
@@ -1,0 +1,79 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0002: Marketplace operator profiles
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Filed from:** [#56](https://github.com/aida-core/aida-marketplace/issues/56)
+
+## Context
+
+AIDA marketplaces vary widely in scope and constraints:
+
+- Some are public, all-OSS, with trusted plugin sources (the upstream `aida-marketplace` is one).
+- Others are private or internal, listing private plugins, with stricter review or compliance requirements.
+- Some are happy to run on hosted services; others have policy requirements to own the entire auth chain.
+
+A single recommended setup can't cover both ends well. Pushing complexity onto a hobby/community operator is wasteful; pushing under-engineered defaults onto a regulated operator is unsafe. Different ADRs (update mechanism, GitHub App, secret management) all bottom out at the same dimension: what kind of marketplace is this?
+
+This ADR defines two named operator profiles. Future ADRs and reference configs slot into one or the other.
+
+## Considered options
+
+1. **One-size-fits-all pattern** — recommend a single canonical setup (e.g., auto-PR + manual merge + own GitHub App for everyone).
+   - Pros: one path to learn, one set of reference configs.
+   - Cons: over-engineered for OSS-only operators, under-equipped for private/internal operators.
+
+2. **Two named profiles: Simple and Enterprise** — both documented with reference configs; operators pick which fits their constraints.
+   - Pros: covers the realistic spectrum; each downstream ADR can target one profile cleanly.
+   - Cons: two reference patterns to maintain; risk of profile drift if operators don't re-declare when their needs change.
+
+3. **Profile-free, freeform** — document the dimensions (hosting, auth, review depth, auto-merge policy) and let each operator pick à la carte.
+   - Pros: maximum flexibility.
+   - Cons: paradox of choice for new operators; combinations diverge wildly, defeating the purpose of upstream guidance.
+
+## Decision
+
+Adopt **option 2**: two named profiles.
+
+### Simple profile
+
+- **Use case:** public marketplace, all-public listings from trusted sources, hobby/community pace.
+- **Update tooling:** Mend-hosted Renovate App (free for public and private repos).
+- **Auth:** App-less — Mend handles GitHub auth.
+- **Auto-merge:** `true` for trusted-source minor/patch updates. Major versions and external sources require dashboard approval.
+- **Safety gate:** strong CI — validator (ADR-0001) + tests + branch protection on `main` with required checks.
+- **Reference config:** [`docs/profiles/renovate-simple.json`](../profiles/renovate-simple.json).
+
+### Enterprise profile
+
+- **Use case:** private or internal marketplace, mixed public + private listings, internal review or compliance requirements.
+- **Update tooling:** self-hosted Renovate (typically in GitHub Actions) or Mend with App-authed access for private-repo reads.
+- **Auth:** own GitHub App (per ADR-0004) for private-repo reads and any cross-repo writes.
+- **Auto-merge:** conservative by default (`false`). Trusted-source minor/patch can be enabled once Renovate operations have been validated against the operator's CI and review policies.
+- **Safety gate:** CI + dashboard approval for external sources and major bumps + audit-logged merges.
+- **Reference config:** [`docs/profiles/renovate-enterprise.json`](../profiles/renovate-enterprise.json).
+
+**`aida-marketplace` adopts the Simple profile.**
+
+## Consequences
+
+**Gained:**
+
+- Operators get a clear "pick a profile" entry point and a reference config they can copy.
+- ADR-0004 (GitHub App) becomes a profile-conditional decision instead of a global one.
+- Issue [#30](https://github.com/aida-core/aida-marketplace/issues/30) (Adopt Renovate) becomes concretely "adopt Renovate for the Simple profile on this repo."
+- Downstream private marketplaces have a named, reusable pattern to mirror.
+
+**Accepted costs:**
+
+- Two reference configs to keep current.
+- Profile drift risk: an operator on Simple might start adopting Enterprise-style gates without explicitly migrating profiles. Mitigation: keep the configs in `docs/profiles/` minimal and version them; ask operators to declare their profile in their README.
+
+## Enforcement
+
+- This ADR is documentation-driven, not validator-enforced. Profile choice belongs to the operator.
+- The reference configs in [`docs/profiles/`](../profiles/) are the canonical examples; downstream operators copy and adapt.
+- Marketplace operators are asked to declare their profile in their README (suggested wording: *"This marketplace operates the **Simple** profile per ADR-0002."*).
+- Per-ADR enforcement (ADR-0001 validator, ADR-0003 suffix check, ADR-0005 author identity, etc.) applies to all profiles unless the ADR explicitly scopes itself to one.

--- a/docs/adr/0003-marketplace-entry-kinds.md
+++ b/docs/adr/0003-marketplace-entry-kinds.md
@@ -1,0 +1,108 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0003: Marketplace entry kinds — plugin and guidebook
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Filed from:** [#55](https://github.com/aida-core/aida-marketplace/issues/55)
+
+## Context
+
+Two semantically distinct kinds of catalog entries are emerging in AIDA marketplaces:
+
+- **Plugins** ship *capability* — skills, slash commands, MCP integrations, agents that perform actions. They answer *"what does this do?"* (e.g., a TDD-enforcement plugin runs tests on a PR.)
+- **Guidebooks** ship *domain knowledge* — a curated set of agents/experts that progressively walks the assistant through a specific area. They answer *"what does this team know?"* (e.g., a contests-domain guidebook with multiple expert agents and progressive disclosure of conventions.)
+
+Conflating the two muddles discovery and installation expectations. A user looking for "scaffold a new X" wants a guidebook; a user looking for "run TDD on this PR" wants a plugin. Same marketplace, different intent.
+
+The current schema has no formal distinction. Listings rely on informal naming conventions that don't always reflect the underlying kind, and on a `category` field that classifies *within* a kind rather than *between* kinds.
+
+## Considered options
+
+1. **Schema field only** — add `kind: "plugin" | "guidebook"` to each entry; require it; let the repo name be anything.
+   - Pros: explicit in the JSON; tools can filter on the field directly.
+   - Cons: the field can drift from repo content if the operator forgets to update it; one source of truth that can lie.
+
+2. **Naming convention only** — every listed entry's source repo must end in `-plugin` or `-guidebook`; no schema field.
+   - Pros: no schema change; suffix visible everywhere (URLs, install paths, Git history).
+   - Cons: less discoverable in the JSON itself; programmatic filters have to parse strings; the suffix is invisible if you're only looking at the manifest.
+
+3. **Dual enforcement: schema field *and* matching suffix** — every entry has both, and the validator (ADR-0001) checks they agree.
+   - Pros: explicit *and* visible everywhere; drift is mechanically impossible (one rule per validator run); operator gets immediate feedback if the two disagree.
+   - Cons: small redundancy in the manifest; every new entry must populate both.
+
+4. **Don't formalize** — leave as informal convention.
+   - Pros: zero cost.
+   - Cons: drift continues; new contributors won't know the distinction exists.
+
+## Decision
+
+Adopt **option 3: dual enforcement**.
+
+Every entry in `marketplace.json` carries:
+
+1. A `kind` field on the entry: `"plugin"` or `"guidebook"`.
+2. A source repo name ending in the matching suffix: `-plugin` or `-guidebook`.
+
+The validator (ADR-0001) enforces:
+
+- `kind` is present and is one of the allowed values.
+- `source.repo` suffix matches `kind` exactly (no `-plugin` repo with `kind: "guidebook"` or vice versa).
+
+Example:
+
+```json
+{
+  "plugins": [
+    {
+      "name": "aida-core",
+      "kind": "plugin",
+      "source": { "repo": "aida-core/aida-core-plugin", "ref": "v1.4.6" }
+    },
+    {
+      "name": "contests",
+      "kind": "guidebook",
+      "source": { "repo": "myorg/contests-guidebook", "ref": "v0.1.0" }
+    }
+  ]
+}
+```
+
+### Why "guidebook"
+
+The original `#55` framing used "playbook," but playbook carries sports/military genre baggage. "Guidebook" captures the same mental model — *a curated work that progressively walks you through a domain* — with no domain-specific flavor. A guidebook isn't a single document; it's a unified work that contains multiple sections/experts inside (travel guidebook → city guide + food guide + transit guide; contests guidebook → onboarding agent + rules agent + scoring agent). That matches the actual content shape: a bundle of agents with progressively disclosed knowledge.
+
+### Why dual enforcement over either alone
+
+- A schema-only rule can be falsified by an operator who updates the field but not the repo (or vice versa).
+- A suffix-only rule keeps the distinction out of the JSON, where tooling and humans naturally look.
+- With both, each source of truth checks the other. The validator catches any disagreement on the first CI run, before merge.
+
+## Consequences
+
+**Gained:**
+
+- Discovery works either way: filter on `kind`, or grep on the suffix.
+- "Field says X, repo says Y" drift is mechanically impossible past the validator.
+- Downstream marketplaces inherit the pattern by adopting the same validator (ADR-0001).
+- The naming convention is self-documenting in URLs and clone paths.
+
+**Accepted costs:**
+
+- Existing repos may need renaming if their suffix doesn't match the kind they actually are. Audit current listings before the rule becomes blocking; remediate in a one-shot PR.
+- Every new entry must populate both fields. Templates and scaffolding should default both correctly.
+- The outer key of `marketplace.json` stays as `plugins` (Claude Code's marketplace schema expects this), even though entries can now be `kind: "guidebook"` too. Minor historical-name awkwardness, accepted in exchange for not forking the upstream schema.
+
+## Enforcement
+
+Validator rule `[ADR-0003]` (per ADR-0001):
+
+- Every `plugins[]` entry has a `kind` field.
+- `kind` value is one of `"plugin"` or `"guidebook"` (closed set; new kinds require an ADR).
+- `source.repo` ends in the matching suffix (`-plugin` for `kind: "plugin"`, `-guidebook` for `kind: "guidebook"`).
+- Failure messages cite this ADR by number and link to it.
+
+**One-time audit:** any current listing without a `kind` field or with a non-conforming suffix gets flagged on the next validator run. Remediate via separate PR before the rule becomes blocking on `main`.
+
+**Scaffolding:** the plugin scaffolder (`aida-core-plugin`) should default `kind` and suffix appropriately based on what the user is creating. Tracked as a follow-up under the validator implementation issue.

--- a/docs/adr/0003-marketplace-entry-kinds.md
+++ b/docs/adr/0003-marketplace-entry-kinds.md
@@ -71,7 +71,13 @@ Example:
 
 ### Why "guidebook"
 
-The original `#55` framing used "playbook," but playbook carries sports/military genre baggage. "Guidebook" captures the same mental model — *a curated work that progressively walks you through a domain* — with no domain-specific flavor. A guidebook isn't a single document; it's a unified work that contains multiple sections/experts inside (travel guidebook → city guide + food guide + transit guide; contests guidebook → onboarding agent + rules agent + scoring agent). That matches the actual content shape: a bundle of agents with progressively disclosed knowledge.
+The original `#55` framing used "playbook," but playbook carries sports/military genre
+baggage. "Guidebook" captures the same mental model — *a curated work that progressively
+walks you through a domain* — with no domain-specific flavor. A guidebook isn't a single
+document; it's a unified work that contains multiple sections/experts inside (travel
+guidebook → city guide + food guide + transit guide; contests guidebook → onboarding agent +
+rules agent + scoring agent). That matches the actual content shape: a bundle of agents with
+progressively disclosed knowledge.
 
 ### Why dual enforcement over either alone
 

--- a/docs/adr/0004-github-app.md
+++ b/docs/adr/0004-github-app.md
@@ -1,0 +1,70 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0004: GitHub App for cross-repo operations
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Filed from:** [#58](https://github.com/aida-core/aida-marketplace/issues/58)
+
+## Context
+
+A GitHub App provides scoped, rotated credentials for workflows that need to:
+
+1. Read release tags from **private** plugin repositories.
+2. Open auto-PRs or issues into **other** repositories (cross-repo writes — e.g., propagating security advisories to plugin repos).
+3. Operate above the default `GITHUB_TOKEN` rate limit (5k req/hr for authenticated App tokens vs. 1k req/hr per workflow run for `GITHUB_TOKEN`).
+
+The default `GITHUB_TOKEN` handles the public-OSS case fine. Apps become essential when private-repo reads, cross-repo writes, or sustained high-volume calls enter the picture.
+
+Under [ADR-0002](./0002-marketplace-profiles.md) (operator profiles), this decision is profile-conditional rather than universal.
+
+## Considered options
+
+1. **Provision an App on the upstream org now** — set up an App for `aida-core`, switch existing workflows to use it.
+   - Pros: ready when needed; a live reference for downstream operators.
+   - Cons: secret rotation overhead, upfront ops work, unused capability today.
+
+2. **No App for Simple profile; required for Enterprise profile** — Simple operators stay App-less via Mend-hosted Renovate; Enterprise operators provision and manage their own App.
+   - Pros: matches the actual need surface; aida-marketplace stays low-ops; clean alignment with ADR-0002.
+   - Cons: when upstream eventually crosses an Enterprise trigger, App setup happens under whatever timeline that trigger sets.
+
+3. **Defer entirely, document nothing** — treat App provisioning as out-of-scope for upstream guidance.
+   - Pros: simplest.
+   - Cons: Enterprise operators recreate the same setup from scratch each time, without a reference pattern.
+
+## Decision
+
+Adopt **option 2**: profile-conditional.
+
+- **Simple profile** (including `aida-marketplace` today): no GitHub App. Mend-hosted Renovate handles auth. Workflows use the default `GITHUB_TOKEN`. This is sufficient for all-public listings.
+- **Enterprise profile**: a GitHub App is required. At minimum it needs `Contents: Read` on the plugin repos being tracked, plus `Pull requests: Write` and `Issues: Write` on the marketplace repo itself. Reference docs and example workflow snippets live in [`docs/profiles/enterprise-github-app.md`](../profiles/enterprise-github-app.md) (to be written under the implementation issue).
+
+### Triggers to migrate `aida-marketplace` from Simple → Enterprise
+
+If any of these become true, revisit this ADR and provision an App:
+
+1. A private plugin is listed (App needed to read release tags from a private repo).
+2. A workflow needs to write into a plugin repo outside this repo's scope (e.g., automated security advisories).
+3. `GITHUB_TOKEN` rate limits start affecting routine runs.
+
+None of these are true today. Track the triggers; don't pre-provision.
+
+## Consequences
+
+**Gained:**
+
+- `aida-marketplace` avoids App secret management until a concrete trigger fires.
+- Enterprise operators get a documented reference pattern, including install steps and the `actions/create-github-app-token@v3` workflow snippet.
+- Clear trigger conditions prevent provisioning capability before there's a use for it.
+
+**Accepted costs:**
+
+- When a trigger fires upstream, App provisioning is a one-time cost paid under that timeline.
+- The Enterprise App reference doc must stay current even though upstream doesn't exercise it.
+
+## Enforcement
+
+- **Simple profile**: no rule. Default `GITHUB_TOKEN` is the assumed auth. If a workflow ever needs broader scope, that's the migration signal.
+- **Enterprise profile**: documented requirement, not validator-enforced. Operators self-attest in their README per ADR-0002.
+- **Reference doc**: [`docs/profiles/enterprise-github-app.md`](../profiles/enterprise-github-app.md) — covers App install, permissions, secret rotation, and the example workflow snippet using `actions/create-github-app-token@v3`. Maintained alongside this ADR.

--- a/docs/adr/0004-github-app.md
+++ b/docs/adr/0004-github-app.md
@@ -38,7 +38,11 @@ Under [ADR-0002](./0002-marketplace-profiles.md) (operator profiles), this decis
 Adopt **option 2**: profile-conditional.
 
 - **Simple profile** (including `aida-marketplace` today): no GitHub App. Mend-hosted Renovate handles auth. Workflows use the default `GITHUB_TOKEN`. This is sufficient for all-public listings.
-- **Enterprise profile**: a GitHub App is required. At minimum it needs `Contents: Read` on the plugin repos being tracked, plus `Pull requests: Write` and `Issues: Write` on the marketplace repo itself. Reference docs and example workflow snippets live in [`docs/profiles/enterprise-github-app.md`](../profiles/enterprise-github-app.md) (to be written under the implementation issue).
+- **Enterprise profile**: a GitHub App is required. At minimum it needs `Contents: Read` on
+  the plugin repos being tracked, plus `Pull requests: Write` and `Issues: Write` on the
+  marketplace repo itself. Reference docs and example workflow snippets live in
+  [`docs/profiles/enterprise-github-app.md`](../profiles/enterprise-github-app.md) (to be
+  written under the implementation issue).
 
 ### Triggers to migrate `aida-marketplace` from Simple → Enterprise
 

--- a/docs/adr/0005-author-and-owner-identity.md
+++ b/docs/adr/0005-author-and-owner-identity.md
@@ -103,12 +103,14 @@ Adopt **option 2: GitHub slug** for both `owner.name` and `plugins[].author.name
 Validator rule `[ADR-0005]` (per [ADR-0001](./0001-validator-language.md)):
 
 **Top-level `owner`:**
+
 - `owner.name` is present.
 - `owner.name` matches GitHub's slug pattern.
 - `owner.email` MUST NOT be present.
 - `owner.url` MUST NOT be present.
 
 **Per-entry `plugins[].author`:**
+
 - `author.name` is present.
 - `author.name` matches GitHub's slug pattern.
 - `author.email` MUST NOT be present.

--- a/docs/adr/0005-author-and-owner-identity.md
+++ b/docs/adr/0005-author-and-owner-identity.md
@@ -1,0 +1,126 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0005: Author and owner identity
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Filed from:** [#59](https://github.com/aida-core/aida-marketplace/issues/59)
+
+## Context
+
+Two places in `marketplace.json` carry identity:
+
+1. **`owner.name`** at the top level — who maintains the marketplace itself.
+2. **`plugins[].author.name`** on each listed entry — who authors the listed plugin or guidebook.
+
+Both currently pin to an individual GitHub username (`"oakensoul"`) with an attached email. This creates the same problems in both places:
+
+- **Misleading attribution** — implies single ownership when there are multiple contributors.
+- **Orphaning** — if the original person rotates out, the field's identity goes stale.
+- **Inconsistent listings** — some entries might pin to individuals, others to org-level names.
+- **Email rotation** — pinning an individual email to a public manifest creates PII and rotation concerns.
+
+Individual contribution attribution already lives in Git history, `AUTHORS`, and `MAINTAINERS.md`. The manifest fields should describe identity in a way that maps to something verifiable.
+
+## Considered options
+
+1. **Per-org canonical display names** — maintain a mapping table (e.g., `aida-core` → `"AIDA Core"`) and require the `name` field to match the table.
+   - Pros: human-readable display names.
+   - Cons: arbitrary mapping table to maintain; no canonical source for the "right" name; doesn't compose with personal-org plugins; new orgs require marketplace updates.
+
+2. **GitHub slug** — every identity field MUST be a valid GitHub slug (an org or user that exists at `github.com/<slug>`).
+   - Pros: single source of truth (GitHub itself); no mapping table; mechanically verifiable; one rule for org-owned and personal entries.
+   - Cons: displays as a slug (`aida-core`) rather than a polished display name (`AIDA Core`); UI consumers wanting display names resolve via GitHub's API.
+
+3. **Keep individual contributor names** — status quo.
+   - Pros: simple.
+   - Cons: all the failure modes in Context.
+
+## Decision
+
+Adopt **option 2: GitHub slug** for both `owner.name` and `plugins[].author.name`.
+
+### Rules
+
+- **`owner.name`** (top-level) MUST be a valid GitHub slug. The marketplace operator chooses whether to use a personal user slug (for solo-maintained marketplaces) or an org slug (for org-owned marketplaces).
+- **`plugins[].author.name`** MUST be a valid GitHub slug. For org-owned plugins, it SHOULD default to the source repo's org slug (e.g., `"aida-core"` for `aida-core/aida-core-plugin`). Individual contributors MAY use their own user slug.
+- **`email` is forbidden** on both `owner` and `plugins[].author`. Repo issues are the contact channel.
+- **`url` is forbidden** on `owner` (redundant — `github.com/<slug>` is implied).
+- A "valid GitHub slug" means: alphanumeric and hyphens, no leading or trailing hyphen, no consecutive hyphens, max 39 characters — and SHOULD exist at `github.com/<slug>` as an org or user (verify-mode check).
+
+### Concrete change for `aida-marketplace`
+
+`owner` becomes:
+
+```json
+{
+  "owner": { "name": "oakensoul" }
+}
+```
+
+(personal handle retained — marketplace-operator choice).
+
+`plugins[0].author` becomes:
+
+```json
+{ "name": "aida-core" }
+```
+
+(org slug, since the plugin lives under `aida-core/`).
+
+### Why GitHub slug instead of canonical display names
+
+- **Single source of truth:** GitHub itself is authoritative. No mapping table to fork, sync, or relitigate.
+- **Symmetry:** orgs and users use the same kind of value; same rule applies everywhere.
+- **Mechanically verifiable:** the validator can pattern-check offline, or hit `https://api.github.com/users/<slug>` or `/orgs/<slug>` to confirm existence.
+- **Composable:** new orgs and users publish without any marketplace update — their slug just works.
+
+### Why drop email and owner.url
+
+- Email tied to an individual creates a rotation problem the moment that person steps back.
+- `owner.url` adds no information beyond `github.com/<owner.name>` and creates drift risk if the slug changes.
+- Less PII surface in a public manifest is always better.
+
+## Consequences
+
+**Gained:**
+
+- One uniform rule for every identity field in the manifest.
+- No canonical-name mapping table to fork or sync.
+- Migration is a small mechanical edit, not a values discussion.
+- Operator choice preserved at the marketplace-owner level (personal vs org slug).
+- UI consumers needing display names resolve them themselves via the GitHub API — separation of concerns.
+
+**Accepted costs:**
+
+- Identity fields display as slugs, not polished display names. Acceptable trade for the simplicity.
+- One-shot migration: update `owner` and the existing plugin's `author` in `marketplace.json`.
+- Scope change for [#46](https://github.com/aida-core/aida-marketplace/issues/46): the "canonical author identity mapped per source org" framing is superseded by this ADR. Close #46 with a pointer here.
+
+## Enforcement
+
+Validator rule `[ADR-0005]` (per [ADR-0001](./0001-validator-language.md)):
+
+**Top-level `owner`:**
+- `owner.name` is present.
+- `owner.name` matches GitHub's slug pattern.
+- `owner.email` MUST NOT be present.
+- `owner.url` MUST NOT be present.
+
+**Per-entry `plugins[].author`:**
+- `author.name` is present.
+- `author.name` matches GitHub's slug pattern.
+- `author.email` MUST NOT be present.
+
+**Optional verify-mode check** (opt-in, off by default to conserve GitHub API rate limit):
+
+- Hit `https://api.github.com/users/<slug>` or `/orgs/<slug>`; expect 200 for every slug in the manifest.
+- When the GitHub App is provisioned (per [ADR-0004](./0004-github-app.md) — Enterprise profile or upstream migration), this check can run on every PR. Until then, leave as an opt-in `make verify-authors` target.
+
+Failure messages cite this ADR.
+
+**Follow-ups:**
+
+- One-shot PR updating `.claude-plugin/marketplace.json` per this ADR (drop email/url from owner; switch author to `"aida-core"`; add `kind: "plugin"` per [ADR-0003](./0003-marketplace-entry-kinds.md)).
+- Close [#46](https://github.com/aida-core/aida-marketplace/issues/46) with a pointer to this ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,35 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Architectural Decision Records
+
+This directory holds **ADRs** — short, immutable documents that record a single architectural decision the project has made, along with the context, options considered, and consequences.
+
+ADRs exist so that conventions are discoverable and decisions don't get relitigated in every PR. Every rule the marketplace enforces should be backed by an ADR, and every ADR should be backed by a mechanical check (validator, CI workflow, schema). See [#42](https://github.com/aida-core/aida-marketplace/issues/42) for the umbrella issue.
+
+## File naming
+
+`NNNN-kebab-case-title.md` — four-digit sequence, no gaps. New ADRs claim the next number.
+
+## Status lifecycle
+
+- **Proposed** — drafted, awaiting acceptance. Discussion happens on the linked issue/PR.
+- **Accepted** — adopted as canonical. The enforcement mechanism is in place (or tracked as a follow-up).
+- **Superseded by NNNN** — replaced by a later ADR. Body is preserved; link to the successor.
+- **Deprecated** — no longer in force, no replacement.
+
+Never edit an Accepted ADR's substance. To change a decision, write a new ADR that supersedes it.
+
+## Template
+
+See [`0000-adr-template.md`](./0000-adr-template.md). Copy it, rename, fill in.
+
+## Index
+
+| #    | Title                                                            | Status   | Filed from |
+| ---- | ---------------------------------------------------------------- | -------- | ---------- |
+| 0001 | [Validator implementation language](./0001-validator-language.md) | Accepted | [#57](https://github.com/aida-core/aida-marketplace/issues/57) |
+| 0002 | [Marketplace operator profiles](./0002-marketplace-profiles.md)  | Accepted | [#56](https://github.com/aida-core/aida-marketplace/issues/56) |
+| 0003 | [Marketplace entry kinds — plugin and guidebook](./0003-marketplace-entry-kinds.md) | Accepted | [#55](https://github.com/aida-core/aida-marketplace/issues/55) |
+| 0004 | [GitHub App for cross-repo operations](./0004-github-app.md)     | Accepted | [#58](https://github.com/aida-core/aida-marketplace/issues/58) |
+| 0005 | [Author and owner identity](./0005-author-and-owner-identity.md) | Accepted | [#59](https://github.com/aida-core/aida-marketplace/issues/59) |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,7 +5,10 @@
 
 This directory holds **ADRs** — short, immutable documents that record a single architectural decision the project has made, along with the context, options considered, and consequences.
 
-ADRs exist so that conventions are discoverable and decisions don't get relitigated in every PR. Every rule the marketplace enforces should be backed by an ADR, and every ADR should be backed by a mechanical check (validator, CI workflow, schema). See [#42](https://github.com/aida-core/aida-marketplace/issues/42) for the umbrella issue.
+ADRs exist so that conventions are discoverable and decisions don't get relitigated in every
+PR. Every rule the marketplace enforces should be backed by an ADR, and every ADR should be
+backed by a mechanical check (validator, CI workflow, schema).
+See [#42](https://github.com/aida-core/aida-marketplace/issues/42) for the umbrella issue.
 
 ## File naming
 
@@ -26,10 +29,10 @@ See [`0000-adr-template.md`](./0000-adr-template.md). Copy it, rename, fill in.
 
 ## Index
 
-| #    | Title                                                            | Status   | Filed from |
-| ---- | ---------------------------------------------------------------- | -------- | ---------- |
+| # | Title | Status | Filed from |
+| --- | --- | --- | --- |
 | 0001 | [Validator implementation language](./0001-validator-language.md) | Accepted | [#57](https://github.com/aida-core/aida-marketplace/issues/57) |
-| 0002 | [Marketplace operator profiles](./0002-marketplace-profiles.md)  | Accepted | [#56](https://github.com/aida-core/aida-marketplace/issues/56) |
+| 0002 | [Marketplace operator profiles](./0002-marketplace-profiles.md) | Accepted | [#56](https://github.com/aida-core/aida-marketplace/issues/56) |
 | 0003 | [Marketplace entry kinds — plugin and guidebook](./0003-marketplace-entry-kinds.md) | Accepted | [#55](https://github.com/aida-core/aida-marketplace/issues/55) |
-| 0004 | [GitHub App for cross-repo operations](./0004-github-app.md)     | Accepted | [#58](https://github.com/aida-core/aida-marketplace/issues/58) |
+| 0004 | [GitHub App for cross-repo operations](./0004-github-app.md) | Accepted | [#58](https://github.com/aida-core/aida-marketplace/issues/58) |
 | 0005 | [Author and owner identity](./0005-author-and-owner-identity.md) | Accepted | [#59](https://github.com/aida-core/aida-marketplace/issues/59) |

--- a/docs/profiles/renovate-enterprise.json
+++ b/docs/profiles/renovate-enterprise.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits"
+  ],
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 10,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track plugin source.ref values in .claude-plugin/marketplace.json as github-releases",
+      "managerFilePatterns": ["^\\.claude-plugin/marketplace\\.json$"],
+      "matchStrings": [
+        "\"repo\":\\s*\"(?<depName>[^\"]+)\"[^}]*?\"ref\":\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Label trusted internal plugin sources. Replace <YOUR_ORG> with your org name; add additional trusted orgs as needed.",
+      "matchDepNames": ["/^<YOUR_ORG>\\//", "/^aida-core\\//"],
+      "addLabels": ["trusted-source"]
+    },
+    {
+      "description": "Gate external (non-trusted) plugin sources on dashboard approval",
+      "matchDatasources": ["github-releases"],
+      "matchDepNames": ["!/^<YOUR_ORG>\\//", "!/^aida-core\\//"],
+      "addLabels": ["external-source"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Major version bumps always require manual review",
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major-version"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Auto-merge disabled by default. Enterprise operators enable per-rule (e.g., trusted-source + minor/patch) once Renovate operations have been validated against the operator's CI and review policies.",
+      "matchDatasources": ["github-releases"],
+      "automerge": false
+    }
+  ]
+}

--- a/docs/profiles/renovate-simple.json
+++ b/docs/profiles/renovate-simple.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits"
+  ],
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 10,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track plugin source.ref values in .claude-plugin/marketplace.json as github-releases",
+      "managerFilePatterns": ["^\\.claude-plugin/marketplace\\.json$"],
+      "matchStrings": [
+        "\"repo\":\\s*\"(?<depName>[^\"]+)\"[^}]*?\"ref\":\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Label trusted aida-core plugin sources",
+      "matchDepNames": ["/^aida-core\\//"],
+      "addLabels": ["trusted-source"]
+    },
+    {
+      "description": "Auto-merge minor/patch updates from trusted sources. Required CI checks (validator + tests) gate the merge.",
+      "matchDatasources": ["github-releases"],
+      "matchDepNames": ["/^aida-core\\//"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "description": "Gate external plugin sources on dashboard approval and label them for review",
+      "matchDatasources": ["github-releases"],
+      "matchDepNames": ["!/^aida-core\\//"],
+      "addLabels": ["external-source"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Major version bumps always require manual review",
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major-version"],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adopt ADR-driven governance for the marketplace (umbrella #42).
- Accept five Phase 1 ADRs from the /discuss issues filed last week.
- Apply the two ADRs that affect the current manifest to `.claude-plugin/marketplace.json`.

## ADRs included

| #    | Title                                          | Decision                                                                                  | Filed from |
| ---- | ---------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------- |
| 0001 | Validator implementation language              | **TypeScript** — extend `update-marketplace.ts` with a `validate` subcommand              | #57        |
| 0002 | Marketplace operator profiles                  | **Simple / Enterprise** profiles; aida-marketplace adopts Simple                          | #56        |
| 0003 | Marketplace entry kinds — plugin and guidebook | **Dual enforcement**: `kind` field + matching `-plugin`/`-guidebook` repo suffix          | #55        |
| 0004 | GitHub App for cross-repo operations           | **Profile-conditional** — no App for Simple, required for Enterprise                      | #58        |
| 0005 | Author and owner identity                      | **GitHub slugs** for `owner.name` and `plugins[].author.name`; no email; no `owner.url`   | #59        |

## What this changes in the manifest

- Adds `kind: "plugin"` on the aida-core entry (ADR-0003).
- Plugin `author` → `{ "name": "aida-core" }` (ADR-0005 — defaults to source-repo org slug).
- Top-level `owner` → `{ "name": "oakensoul" }` (operator choice; personal handle retained, email + url dropped).

## What this does NOT change

- The TypeScript validator (ADR-0001) is not implemented yet — that's the Phase 2 work (#42, #43–46, #50, #54).
- Renovate is not installed yet — that's #30, blocked only on this PR landing so the Simple-profile reference config is in place.
- The `-guidebook` suffix isn't enforced yet — validator + audit happen in Phase 2.

## Closes

- Closes #55 (capability vs knowledge — resolved by ADR-0003)
- Closes #56 (update mechanism — resolved by ADR-0002)
- Closes #57 (validator language — resolved by ADR-0001)
- Closes #58 (GitHub App — resolved by ADR-0004)
- Closes #59 (plugin author identity — resolved by ADR-0005)
- Closes #46 (canonical author identity per source org — superseded by ADR-0005)

## Test plan

- [ ] `make lint-json` passes on the updated `marketplace.json` (verified locally)
- [ ] `make lint-reuse` passes (SPDX headers in place on all new files; JSON covered by REUSE.toml aggregate)
- [ ] `make lint-md` passes (CI will run it; locally blocked on `markdownlint-cli2` not being installed)
- [ ] Review each ADR's Decision and Enforcement sections
- [ ] Spot-check the example JSON in ADR-0003 matches the actual updated `marketplace.json`