### PR TITLE
chore: adopt Renovate via the org-level shared config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- `renovate.json` adopting the Simple profile per ADR-0002. Extends
+  the org-level Renovate config at
+  [`aida-core/.github`](https://github.com/aida-core/.github/blob/main/default.json)
+  (which provides the marketplace.json regex manager, labeling
+  rules, and dashboard-approval gating). Adds the Simple-profile
+  override: auto-merge minor/patch updates from `aida-core/*`
+  sources behind required CI checks. Majors and external sources
+  go through dashboard approval per the inherited org rules.
 - `docs/adr/` directory adopting ADR-driven governance for the
   marketplace (umbrella #42). Five Phase 1 ADRs accepted from the
   /discuss issues filed in May:

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "aida-marketplace adopts the Simple profile per ADR-0002. Extends the org-level Renovate config in aida-core/.github (default.json) and enables auto-merge for trusted-source minor/patch updates.",
+  "extends": [
+    "github>aida-core/.github"
+  ],
+  "packageRules": [
+    {
+      "description": "Auto-merge minor/patch updates from trusted aida-core/* sources. Required CI checks (validator + tests) gate the merge.",
+      "matchDatasources": ["github-releases"],
+      "matchDepNames": ["/^aida-core\\//"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `renovate.json` extending the new org-level Renovate defaults at [`aida-core/.github`](https://github.com/aida-core/.github/blob/main/default.json).
- Adopt the **Simple** operator profile per [ADR-0002](./docs/adr/0002-marketplace-profiles.md): auto-merge minor/patch updates from `aida-core/*` sources behind the required CI checks.
- Add a [Unreleased] CHANGELOG entry describing the change.

## What the org config provides (inherited)

- The `marketplace.json` regex manager (tracks `source.ref` values as `github-releases`).
- Labeling rules: `trusted-source` for `aida-core/*`, `external-source` for others (gated on dashboard approval), `major-version` for major bumps (also gated).
- `prHourlyLimit: 4` / `prConcurrentLimit: 10` to keep CI burst under control.

## What this repo adds on top

The Simple-profile override: auto-merge `aida-core/*` minor/patch updates. The required CI checks (validator + tests) are the safety gate.

## What this does NOT change

- `.github/workflows/check-updates.yml` (the bespoke auto-PR workflow) is left in place as a fallback while Renovate beds in. Remove in a follow-up after a couple of Renovate cycles look clean.

## Closes

- Closes #30 — Adopt Renovate for plugin version management.

## Test plan

- [ ] Renovate dashboard for `aida-core/aida-marketplace` picks up the new config on next scan
- [ ] Once Renovate opens its first PR (or sees no drift today), confirm it inherits the org-level labels and rules
- [ ] After 1-2 update cycles look clean, follow-up PR removes `.github/workflows/check-updates.yml`