### PR TITLE
feat: marketplace validator foundation (ADR-0001) with ADR-0003 + ADR-0005 rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,13 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
-      - name: Validate plugins
+      - name: Run unit tests
+        run: npm test
+
+      - name: Validate marketplace.json (per ADR-0001)
+        run: npm run validate
+
+      - name: Plugin version check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- `scripts/validate-marketplace.ts` — the marketplace validator
+  (per ADR-0001). Pluggable rule framework that emits per-finding
+  `OK` / `FAIL` records with the originating ADR number in the
+  message. Wired into CI as a blocking gate.
+- `scripts/marketplace-types.ts` — shared TypeScript types for the
+  manifest, imported by both `update-marketplace.ts` and
+  `validate-marketplace.ts` so the two stay in sync.
+- `scripts/validate-marketplace.test.ts` — unit tests for the
+  validator and its rules. Uses Node's built-in `node:test` so no
+  new test-framework dependency is required.
+- Two enforced rules in the validator:
+  - `[ADR-0003]` — every `plugins[]` entry has `kind` (`plugin`
+    or `guidebook`) and its `source.repo` ends in the matching
+    suffix.
+  - `[ADR-0005]` — `owner.name` and every `plugins[].author.name`
+    is a valid GitHub slug; `email` is forbidden on both;
+    `owner.url` is forbidden.
+- `make validate` / `make test` targets and `npm run validate` /
+  `npm test` scripts that exercise the validator and the test
+  suite respectively.
 - `renovate.json` adopting the Simple profile per ADR-0002. Extends
   the org-level Renovate config at
   [`aida-core/.github`](https://github.com/aida-core/.github/blob/main/default.json)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # AIDA Marketplace Makefile
 # Run `make help` for available targets
 
-.PHONY: help install lint lint-yaml lint-md lint-json lint-reuse typecheck check
+.PHONY: help install lint lint-yaml lint-md lint-json lint-reuse typecheck check validate test
 
 help: ## Show this help message
 	@echo "AIDA Marketplace - Available targets:"
@@ -38,3 +38,9 @@ typecheck: ## Run TypeScript typecheck
 
 check: ## Run plugin version check
 	npm run check
+
+validate: ## Run marketplace.json rule validation (per ADR-0001)
+	npm run validate
+
+test: ## Run unit tests
+	npm test

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "check": "tsx scripts/update-marketplace.ts",
     "update": "tsx scripts/update-marketplace.ts --update",
+    "validate": "tsx scripts/validate-marketplace.ts",
+    "test": "tsx --test scripts/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/scripts/marketplace-types.ts
+++ b/scripts/marketplace-types.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+// SPDX-License-Identifier: MPL-2.0
+
+// Shared type definitions for the AIDA marketplace manifest. Imported by
+// scripts/update-marketplace.ts (write side) and scripts/validate-marketplace.ts
+// (read-only rule enforcement). Field-level rules are enforced by the
+// validator, not the type system — types describe shape, validator describes
+// policy (per ADR-0001).
+
+export interface PluginSource {
+  source: string;
+  repo: string;
+  ref: string;
+}
+
+export interface PluginAuthor {
+  name: string;
+  // email is allowed by the schema but forbidden by ADR-0005's validator rule.
+  // It stays in the type so legacy manifests still typecheck during migration.
+  email?: string;
+}
+
+export type PluginKind = "plugin" | "guidebook";
+
+export interface Plugin {
+  name: string;
+  // `kind` is required by ADR-0003 but optional in the type for the same
+  // migration reason. The validator emits a FAIL when it's missing.
+  kind?: PluginKind;
+  source: PluginSource;
+  description: string;
+  version: string;
+  category: string;
+  homepage?: string;
+  author?: PluginAuthor;
+  tags: string[];
+}
+
+export interface MarketplaceOwner {
+  name: string;
+  // ADR-0005 forbids both of these on owner. Same migration reasoning.
+  email?: string;
+  url?: string;
+}
+
+export interface Marketplace {
+  name: string;
+  version: string;
+  description: string;
+  owner: MarketplaceOwner;
+  plugins: Plugin[];
+}

--- a/scripts/update-marketplace.ts
+++ b/scripts/update-marketplace.ts
@@ -6,41 +6,9 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// --- Types ---
+import type { Marketplace, Plugin } from "./marketplace-types.js";
 
-interface PluginAuthor {
-  name: string;
-  email: string;
-}
-
-interface PluginSource {
-  source: string;
-  repo: string;
-  ref: string;
-}
-
-interface Plugin {
-  name: string;
-  source: PluginSource;
-  description: string;
-  version: string;
-  category: string;
-  homepage?: string;
-  author?: PluginAuthor;
-  tags: string[];
-}
-
-interface Marketplace {
-  name: string;
-  version: string;
-  description: string;
-  owner: {
-    name: string;
-    email: string;
-    url: string;
-  };
-  plugins: Plugin[];
-}
+// --- Script-local types ---
 
 interface CheckResult {
   plugin: string;

--- a/scripts/validate-marketplace.test.ts
+++ b/scripts/validate-marketplace.test.ts
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+// SPDX-License-Identifier: MPL-2.0
+
+// Unit tests for the marketplace validator. Run via `npm test` (or
+// `make test`). Uses Node's built-in test runner — no extra deps.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { adr0003, adr0005, isValidGitHubSlug } from "./validate-marketplace.js";
+import type { Marketplace, Plugin } from "./marketplace-types.js";
+
+function baseMarketplace(): Marketplace {
+  return {
+    name: "test",
+    version: "0.1.0",
+    description: "",
+    owner: { name: "aida-core" },
+    plugins: [],
+  };
+}
+
+function basePlugin(overrides: Partial<Plugin> = {}): Plugin {
+  return {
+    name: "example",
+    kind: "plugin",
+    source: { source: "github", repo: "aida-core/example-plugin", ref: "v1.0.0" },
+    description: "An example.",
+    version: "1.0.0",
+    category: "core",
+    author: { name: "aida-core" },
+    tags: ["example"],
+    ...overrides,
+  };
+}
+
+describe("isValidGitHubSlug", () => {
+  it("accepts a simple lowercase slug", () => {
+    assert.equal(isValidGitHubSlug("aida-core"), true);
+  });
+
+  it("accepts a single-character slug", () => {
+    assert.equal(isValidGitHubSlug("a"), true);
+  });
+
+  it("accepts mixed-case", () => {
+    assert.equal(isValidGitHubSlug("Oakensoul"), true);
+  });
+
+  it("rejects empty string", () => {
+    assert.equal(isValidGitHubSlug(""), false);
+  });
+
+  it("rejects leading hyphen", () => {
+    assert.equal(isValidGitHubSlug("-foo"), false);
+  });
+
+  it("rejects trailing hyphen", () => {
+    assert.equal(isValidGitHubSlug("foo-"), false);
+  });
+
+  it("rejects consecutive hyphens", () => {
+    assert.equal(isValidGitHubSlug("foo--bar"), false);
+  });
+
+  it("rejects underscore", () => {
+    assert.equal(isValidGitHubSlug("foo_bar"), false);
+  });
+
+  it("rejects slash (path-like)", () => {
+    assert.equal(isValidGitHubSlug("aida-core/aida-core-plugin"), false);
+  });
+
+  it("rejects slugs longer than 39 chars", () => {
+    assert.equal(isValidGitHubSlug("a".repeat(40)), false);
+  });
+
+  it("accepts a 39-char slug", () => {
+    assert.equal(isValidGitHubSlug("a".repeat(39)), true);
+  });
+});
+
+describe("ADR-0003 rule (kind + matching suffix)", () => {
+  it("passes when kind matches the source.repo suffix", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin());
+    const findings = adr0003.check(m);
+    assert.equal(findings.filter((f) => f.status === "FAIL").length, 0);
+    assert.equal(findings.filter((f) => f.status === "OK").length, 1);
+  });
+
+  it("passes for a guidebook with matching -guidebook suffix", () => {
+    const m = baseMarketplace();
+    m.plugins.push(
+      basePlugin({
+        name: "contests",
+        kind: "guidebook",
+        source: { source: "github", repo: "aida-core/contests-guidebook", ref: "v0.1.0" },
+      }),
+    );
+    const findings = adr0003.check(m);
+    assert.equal(findings.filter((f) => f.status === "FAIL").length, 0);
+  });
+
+  it("fails when kind is missing", () => {
+    const m = baseMarketplace();
+    const p = basePlugin();
+    delete (p as { kind?: unknown }).kind;
+    m.plugins.push(p);
+    const fails = adr0003.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /kind.*required/i);
+  });
+
+  it("fails when kind is not in the allowed set", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ kind: "playbook" as unknown as Plugin["kind"] }));
+    const fails = adr0003.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /must be one of/i);
+  });
+
+  it("fails when kind=plugin but suffix is -guidebook", () => {
+    const m = baseMarketplace();
+    m.plugins.push(
+      basePlugin({
+        source: { source: "github", repo: "aida-core/example-guidebook", ref: "v1.0.0" },
+      }),
+    );
+    const fails = adr0003.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /-plugin/);
+  });
+
+  it("returns one finding per plugin", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ name: "a" }));
+    m.plugins.push(basePlugin({ name: "b" }));
+    const findings = adr0003.check(m);
+    assert.equal(findings.length, 2);
+  });
+});
+
+describe("ADR-0005 rule (slug identity, no email, no owner.url)", () => {
+  it("passes for a clean owner + clean plugin author", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin());
+    const findings = adr0005.check(m);
+    assert.equal(findings.filter((f) => f.status === "FAIL").length, 0);
+  });
+
+  it("fails when owner.name is not a valid slug", () => {
+    const m = baseMarketplace();
+    m.owner.name = "foo bar"; // space is invalid
+    const fails = adr0005.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /not a valid GitHub slug/);
+  });
+
+  it("fails when owner.email is present", () => {
+    const m = baseMarketplace();
+    m.owner.email = "rj@example.com";
+    const fails = adr0005.check(m).filter((f) => f.status === "FAIL");
+    assert.ok(fails.some((f) => /owner.email/i.test(f.message)));
+  });
+
+  it("fails when owner.url is present", () => {
+    const m = baseMarketplace();
+    m.owner.url = "https://example.com";
+    const fails = adr0005.check(m).filter((f) => f.status === "FAIL");
+    assert.ok(fails.some((f) => /owner.url/i.test(f.message)));
+  });
+
+  it("fails when plugin author.name is missing", () => {
+    const m = baseMarketplace();
+    const p = basePlugin();
+    delete (p as { author?: unknown }).author;
+    m.plugins.push(p);
+    const fails = adr0005.check(m).filter((f) => f.status === "FAIL");
+    assert.ok(fails.some((f) => /author.name.*required/i.test(f.message)));
+  });
+
+  it("fails when plugin author.name is not a valid slug", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ author: { name: "AIDA Core" } })); // space invalid
+    const fails = adr0005.check(m).filter((f) => f.status === "FAIL");
+    assert.ok(fails.some((f) => /not a valid GitHub slug/.test(f.message)));
+  });
+
+  it("fails when plugin author.email is present", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ author: { name: "aida-core", email: "ops@example.com" } }));
+    const fails = adr0005.check(m).filter((f) => f.status === "FAIL");
+    assert.ok(fails.some((f) => /author.email/i.test(f.message)));
+  });
+
+  it("passes for a multi-plugin manifest with all-clean entries", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ name: "a" }));
+    m.plugins.push(
+      basePlugin({
+        name: "b",
+        kind: "guidebook",
+        source: { source: "github", repo: "aida-core/b-guidebook", ref: "v0.1.0" },
+      }),
+    );
+    const findings = adr0005.check(m);
+    assert.equal(findings.filter((f) => f.status === "FAIL").length, 0);
+  });
+});

--- a/scripts/validate-marketplace.ts
+++ b/scripts/validate-marketplace.ts
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+// SPDX-License-Identifier: MPL-2.0
+
+// Marketplace validator (per ADR-0001).
+//
+// Reads .claude-plugin/marketplace.json and runs each registered rule. Each
+// rule emits per-finding OK / FAIL records with the originating ADR number in
+// the message. Exits 1 if any rule produced a FAIL; 0 otherwise.
+//
+// Adding a new rule:
+//   1. Write an ADR under docs/adr/.
+//   2. Add a Rule export in this file (or a new module imported here).
+//   3. Add it to the RULES list at the bottom.
+//   4. Add unit tests in scripts/validate-marketplace.test.ts.
+//
+// Each rule's failure messages MUST cite the ADR by id (e.g. `[ADR-0003]`)
+// so contributors can find the rationale without leaving the terminal.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { Marketplace, Plugin } from "./marketplace-types.js";
+
+// --- Types ---
+
+export type FindingStatus = "OK" | "FAIL";
+
+export interface Finding {
+  /** ADR identifier, e.g. "ADR-0003". */
+  rule: string;
+  status: FindingStatus;
+  /** Manifest path or human-friendly locator, e.g. `plugins[0] (aida-core)`. */
+  context: string;
+  message: string;
+}
+
+export interface Rule {
+  /** ADR identifier, e.g. "ADR-0003". */
+  id: string;
+  /** One-line description of what the rule enforces. */
+  title: string;
+  /** Run the check; return one or more findings. */
+  check(marketplace: Marketplace): Finding[];
+}
+
+// --- Slug helper (ADR-0005) ---
+
+/**
+ * Returns true iff `slug` matches GitHub's username/org rules: alphanumeric or
+ * hyphens, no leading/trailing hyphen, no consecutive hyphens, 1-39 chars.
+ */
+export function isValidGitHubSlug(slug: string): boolean {
+  if (typeof slug !== "string") return false;
+  if (slug.length < 1 || slug.length > 39) return false;
+  // Must start and end with alphanumeric; interior chars are alphanumeric or
+  // single hyphens (never consecutive).
+  return /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(slug);
+}
+
+// --- Rule: ADR-0003 (kind field + matching repo suffix) ---
+
+function pluginContext(plugin: Plugin, index: number): string {
+  return `plugins[${index}] (${plugin.name})`;
+}
+
+export const adr0003: Rule = {
+  id: "ADR-0003",
+  title: "Marketplace entry kinds: plugin / guidebook with matching suffix",
+  check(marketplace) {
+    const findings: Finding[] = [];
+    marketplace.plugins.forEach((plugin, i) => {
+      const ctx = pluginContext(plugin, i);
+      const kind = plugin.kind;
+
+      if (kind === undefined) {
+        findings.push({
+          rule: "ADR-0003",
+          status: "FAIL",
+          context: ctx,
+          message: "`kind` is required (must be \"plugin\" or \"guidebook\").",
+        });
+        return;
+      }
+
+      if (kind !== "plugin" && kind !== "guidebook") {
+        findings.push({
+          rule: "ADR-0003",
+          status: "FAIL",
+          context: ctx,
+          message: `\`kind\` is "${kind}"; must be one of "plugin" or "guidebook".`,
+        });
+        return;
+      }
+
+      const expectedSuffix = `-${kind}`;
+      if (!plugin.source.repo.endsWith(expectedSuffix)) {
+        findings.push({
+          rule: "ADR-0003",
+          status: "FAIL",
+          context: ctx,
+          message:
+            `source.repo "${plugin.source.repo}" must end with "${expectedSuffix}" ` +
+            `to match \`kind: "${kind}"\`.`,
+        });
+        return;
+      }
+
+      findings.push({
+        rule: "ADR-0003",
+        status: "OK",
+        context: ctx,
+        message: `kind="${kind}" matches repo suffix`,
+      });
+    });
+    return findings;
+  },
+};
+
+// --- Rule: ADR-0005 (GitHub slug identity; no email; no owner.url) ---
+
+export const adr0005: Rule = {
+  id: "ADR-0005",
+  title: "Author and owner identity: GitHub slug, no email, no owner.url",
+  check(marketplace) {
+    const findings: Finding[] = [];
+
+    // owner.name
+    if (!marketplace.owner || typeof marketplace.owner.name !== "string") {
+      findings.push({
+        rule: "ADR-0005",
+        status: "FAIL",
+        context: "owner",
+        message: "`owner.name` is required.",
+      });
+    } else if (!isValidGitHubSlug(marketplace.owner.name)) {
+      findings.push({
+        rule: "ADR-0005",
+        status: "FAIL",
+        context: "owner",
+        message: `\`owner.name\` "${marketplace.owner.name}" is not a valid GitHub slug.`,
+      });
+    } else {
+      findings.push({
+        rule: "ADR-0005",
+        status: "OK",
+        context: "owner",
+        message: `owner.name "${marketplace.owner.name}" is a valid GitHub slug`,
+      });
+    }
+
+    // owner forbidden fields
+    if (marketplace.owner?.email !== undefined) {
+      findings.push({
+        rule: "ADR-0005",
+        status: "FAIL",
+        context: "owner",
+        message: "`owner.email` MUST NOT be present (contact via repo issues).",
+      });
+    }
+    if (marketplace.owner?.url !== undefined) {
+      findings.push({
+        rule: "ADR-0005",
+        status: "FAIL",
+        context: "owner",
+        message:
+          "`owner.url` MUST NOT be present " +
+          "(derivable from owner.name as https://github.com/<owner.name>).",
+      });
+    }
+
+    // each plugin's author
+    marketplace.plugins.forEach((plugin, i) => {
+      const ctx = pluginContext(plugin, i);
+      const author = plugin.author;
+
+      if (!author || typeof author.name !== "string") {
+        findings.push({
+          rule: "ADR-0005",
+          status: "FAIL",
+          context: ctx,
+          message: "`author.name` is required.",
+        });
+        return;
+      }
+
+      if (!isValidGitHubSlug(author.name)) {
+        findings.push({
+          rule: "ADR-0005",
+          status: "FAIL",
+          context: ctx,
+          message: `\`author.name\` "${author.name}" is not a valid GitHub slug.`,
+        });
+        return;
+      }
+
+      if (author.email !== undefined) {
+        findings.push({
+          rule: "ADR-0005",
+          status: "FAIL",
+          context: ctx,
+          message: "`author.email` MUST NOT be present (contact via repo issues).",
+        });
+        return;
+      }
+
+      findings.push({
+        rule: "ADR-0005",
+        status: "OK",
+        context: ctx,
+        message: `author.name "${author.name}" is a valid GitHub slug`,
+      });
+    });
+
+    return findings;
+  },
+};
+
+// --- Registry ---
+
+export const RULES: readonly Rule[] = [adr0003, adr0005] as const;
+
+// --- Reporter ---
+
+function formatFinding(f: Finding): string {
+  const symbol = f.status === "OK" ? "✓" : "✗";
+  return `[${f.rule}] ${symbol} ${f.context}: ${f.message}`;
+}
+
+export function report(findings: readonly Finding[]): number {
+  let failCount = 0;
+  let okCount = 0;
+
+  for (const f of findings) {
+    const line = formatFinding(f);
+    if (f.status === "FAIL") {
+      failCount += 1;
+      console.error(line);
+    } else {
+      okCount += 1;
+      console.log(line);
+    }
+  }
+
+  console.log("");
+  console.log(`Validator summary: ${okCount} passing, ${failCount} failing.`);
+  if (failCount > 0) {
+    console.error(
+      "Failed checks cite ADR numbers. See docs/adr/<NNNN>-*.md for the rationale " +
+        "and the canonical rule wording.",
+    );
+  }
+  return failCount;
+}
+
+// --- Main ---
+
+export function runRules(marketplace: Marketplace): Finding[] {
+  const findings: Finding[] = [];
+  for (const rule of RULES) {
+    findings.push(...rule.check(marketplace));
+  }
+  return findings;
+}
+
+function main(): void {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const root = resolve(__dirname, "..");
+  const manifestPath = resolve(root, ".claude-plugin", "marketplace.json");
+
+  let raw: string;
+  try {
+    raw = readFileSync(manifestPath, "utf-8");
+  } catch (err) {
+    console.error(`[ERROR] could not read ${manifestPath}: ${(err as Error).message}`);
+    process.exit(2);
+  }
+
+  let marketplace: Marketplace;
+  try {
+    marketplace = JSON.parse(raw) as Marketplace;
+  } catch (err) {
+    console.error(`[ERROR] ${manifestPath} is not valid JSON: ${(err as Error).message}`);
+    process.exit(2);
+  }
+
+  const findings = runRules(marketplace);
+  const failures = report(findings);
+  process.exit(failures > 0 ? 1 : 0);
+}
+
+const invoked = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (invoked) {
+  main();
+}


### PR DESCRIPTION
## Summary

Establish the marketplace validator called for by [ADR-0001](./docs/adr/0001-validator-language.md) — the umbrella governance pattern in #42. Each rule is backed by an accepted ADR and cites the ADR number in its failure messages, so CI output stays self-explanatory.

## What lands

- `scripts/marketplace-types.ts` — shared manifest types, imported by both `update-marketplace.ts` (write side) and the new validator (read-only). Field-level rules are enforced by the validator, not by the type system.
- `scripts/validate-marketplace.ts` — pluggable `Rule` registry, reporter, and main entry. Reads `.claude-plugin/marketplace.json`, runs each rule, exits `1` if any rule emitted a `FAIL`.
- `scripts/validate-marketplace.test.ts` — 25 unit tests using Node's built-in `node:test` (no new test-framework dep).
- `make validate` / `make test` and `npm run validate` / `npm test` scripts.
- CI: the `TypeScript` job now runs tests + validator on every PR — blocking gate from day one.

## Rules enforced

| Rule | Source ADR | What it checks |
| --- | --- | --- |
| `[ADR-0003]` | [ADR-0003](./docs/adr/0003-marketplace-entry-kinds.md) | Each `plugins[]` entry has `kind` ∈ {`plugin`, `guidebook`}; `source.repo` ends in `-<kind>` |
| `[ADR-0005]` | [ADR-0005](./docs/adr/0005-author-and-owner-identity.md) | `owner.name` and each `plugins[].author.name` is a valid GitHub slug; no `email` on either; no `owner.url` |

## Local verification

- `npm run typecheck` ✓
- `npm test` ✓ (25/25)
- `npm run validate` ✓ on the current `.claude-plugin/marketplace.json` (3 findings, all `OK`)

## Out of scope (follow-up PRs)

Each subsequent rule lands with its own ADR + validator section per #42's policy:

- `#43` — semver-tag refs (needs ADR drafted)
- `#44` — `.claude-plugin/aida-config.json` required on every listed plugin (needs ADR + fetches external repo state)
- `#45` — closed allow-list for plugin categories (needs ADR defining the allowed set)
- `#50` — JSON Schemas for `marketplace.json` + frontmatter
- `#54` — separate `validate-frontmatter.py` for markdown frontmatter

## Refs

- Refs #42 — partial implementation of the ADR-driven governance umbrella

## Test plan

- [x] Local typecheck passes
- [x] Local unit tests pass (25/25)
- [x] Local validator passes on the current manifest (3 OK findings)
- [ ] CI: TypeScript / Lint / No AI Co-Authors / Changelog all green
- [ ] Spot-check the validator output by tweaking the manifest locally before review