### PR TITLE
feat(validator): require semver-tag refs (ADR-0006) + own-source age exemption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- ADR-0006: plugin `source.ref` values must be semver tags
+  (`v?\d+\.\d+\.\d+`). Branches, SHAs, non-semver tags, and
+  pre-release/build-metadata tags are all forbidden. Filed from #43.
+- Validator rule `[ADR-0006]` enforcing the above. Non-github
+  sources are skipped (rule applies only to github refs).
+- `SKIP` status on validator findings (in addition to `OK` / `FAIL`)
+  for rules that don't apply to a given entry. The reporter
+  surfaces the skipped-count in the summary line.
 - `scripts/validate-marketplace.ts` — the marketplace validator
   (per ADR-0001). Pluggable rule framework that emits per-finding
   `OK` / `FAIL` records with the originating ADR number in the
@@ -87,6 +95,12 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Changed
 
+- `renovate.json` now overrides the org-wide
+  `minimumReleaseAge: "14 days"` to `0 days` for `aida-core/*`
+  source updates. We own those plugins; the 14-day supply-chain
+  gate exists to protect against compromised external dependencies,
+  not internal releases that already get full review at their own
+  repos. CI checks here still gate the auto-merge.
 - `.claude-plugin/marketplace.json` migrated to comply with ADR-0003
   and ADR-0005: added `kind: "plugin"` to the aida-core entry;
   changed the per-plugin `author` to `{ "name": "aida-core" }`

--- a/docs/adr/0006-semver-tag-refs.md
+++ b/docs/adr/0006-semver-tag-refs.md
@@ -1,0 +1,114 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0006: Plugin source refs must be semver tags
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Filed from:** [#43](https://github.com/aida-core/aida-marketplace/issues/43)
+
+## Context
+
+Each `plugins[].source.ref` in `marketplace.json` is a Git reference — a tag,
+branch, or commit SHA. Today the field is unconstrained. That allows three
+failure modes the marketplace doesn't want:
+
+- **Branches drift silently.** A `ref: "main"` floats as the plugin author
+  commits; consumers installing the plugin end up with whatever was on `main`
+  at the moment of install, with no version pinning.
+- **SHAs are unreadable.** A 40-char hex string in the manifest gives no
+  signal about *what* version is pinned. Reviewers can't tell whether a bump
+  is a patch or a major version.
+- **Non-semver tags are unstable contracts.** A tag like `"release-2024-01"`
+  doesn't compose with semver-aware tooling (Renovate, the existing version
+  comparator in `update-marketplace.ts`, the validator's downstream rules).
+
+The marketplace is a public catalog of plugin pins. Pins should be specific,
+versioned, and machine-comparable.
+
+## Considered options
+
+1. **Forbid branches and SHAs, allow any Git tag.**
+   - Pros: minimal restriction; any release tagging convention works.
+   - Cons: non-semver tags (`release-2024-01`, `stable`) still break tooling
+     that does version math.
+
+2. **Require strict semver tags (`v?\d+\.\d+\.\d+`).**
+   - Pros: composes with all semver-aware tooling; consumers can reason
+     about version deltas; matches the convention `update-marketplace.ts`
+     already enforces via `isValidSemver`.
+   - Cons: forbids legitimate pre-release pins (`v1.2.3-rc1`).
+
+3. **Allow full semver including pre-releases (`v?\d+\.\d+\.\d+(-.+)?`).**
+   - Pros: enables pinning to release candidates for testing.
+   - Cons: pre-releases in a public catalog are usually a mistake; they
+     surface unstable code to consumers who expect stability.
+
+4. **Require strict semver with mandatory `v` prefix (`v\d+\.\d+\.\d+`).**
+   - Pros: enforces one consistent style.
+   - Cons: extra restriction with no functional benefit; some plugin repos
+     legitimately tag without the `v`.
+
+## Decision
+
+Adopt **option 2: strict semver tags, `v` prefix optional**.
+
+The validator MUST accept `source.ref` values matching `^v?\d+\.\d+\.\d+$` and
+reject everything else, including:
+
+- Branch names (`main`, `develop`, `next`).
+- Commit SHAs (40-char hex).
+- Non-semver tags (`release-2024-01`, `stable`, `latest`).
+- Pre-release tags (`v1.2.3-rc1`, `v1.2.3-beta.2`).
+- Build-metadata tags (`v1.2.3+sha.abc123`).
+
+Rationale:
+
+- The marketplace is a stability boundary. Pins should be specific, stable,
+  machine-comparable releases — not branches that drift, not pre-releases
+  that surface unstable code, not opaque SHAs.
+- Renovate's `extractVersionTemplate` already strips the optional `v` prefix
+  (per the org-level config in `aida-core/.github`), so accepting either form
+  costs nothing.
+- The existing `isValidSemver` helper in `update-marketplace.ts` uses the
+  same regex; this ADR canonicalizes that convention.
+
+If a plugin author needs pre-release exposure to specific consumers, the
+right channel is a separate pre-release marketplace, not the upstream
+catalog — same pattern as ADR-0002's Simple vs Enterprise profile split.
+
+## Consequences
+
+**Gained:**
+
+- Manifest pins are guaranteed to be specific, semver-comparable releases.
+- Renovate, the validator, and downstream tooling can do version math
+  without special cases.
+- Reviewers can tell at a glance whether a bump is patch / minor / major.
+
+**Accepted costs:**
+
+- Pre-release testing requires a different channel (testing fork, separate
+  marketplace, or direct repo install). The public catalog is for stable
+  releases only.
+- Plugin repos must publish semver tags; non-semver release schemes
+  (date-based, etc.) are incompatible. In practice this aligns with
+  AIDA's existing convention.
+- This rule is sibling to ADR-0001 (validator language) and ADR-0003
+  (entry kinds); it does not affect other ADR-defined rules.
+
+## Enforcement
+
+Validator rule `[ADR-0006]` (per [ADR-0001](./0001-validator-language.md)):
+
+- Every `plugins[]` entry whose `source.source === "github"` has a
+  `source.ref` matching `^v?\d+\.\d+\.\d+$`.
+- Non-github sources are SKIPPED (the rule applies only to GitHub refs).
+- Missing `source.ref` is a FAIL.
+- Failure messages cite this ADR.
+
+The check is offline and pattern-based — no network calls. The validator
+does not verify that the tag *exists* on the source repo; that's covered
+by the existing `update-marketplace.ts --check` flow (which does fetch
+release tags via the GitHub API) and by Renovate (which fails the auto-
+update PR if the tag can't be resolved).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,4 @@ See [`0000-adr-template.md`](./0000-adr-template.md). Copy it, rename, fill in.
 | 0003 | [Marketplace entry kinds — plugin and guidebook](./0003-marketplace-entry-kinds.md) | Accepted | [#55](https://github.com/aida-core/aida-marketplace/issues/55) |
 | 0004 | [GitHub App for cross-repo operations](./0004-github-app.md) | Accepted | [#58](https://github.com/aida-core/aida-marketplace/issues/58) |
 | 0005 | [Author and owner identity](./0005-author-and-owner-identity.md) | Accepted | [#59](https://github.com/aida-core/aida-marketplace/issues/59) |
+| 0006 | [Plugin source refs must be semver tags](./0006-semver-tag-refs.md) | Accepted | [#43](https://github.com/aida-core/aida-marketplace/issues/43) |

--- a/renovate.json
+++ b/renovate.json
@@ -6,10 +6,11 @@
   ],
   "packageRules": [
     {
-      "description": "Auto-merge minor/patch updates from trusted aida-core/* sources. Required CI checks (validator + tests) gate the merge.",
+      "description": "Auto-merge minor/patch updates from trusted aida-core/* sources. We own these plugins, so they bypass the org-wide 14-day minimumReleaseAge gate (release review happens at the plugin repos themselves). Required CI checks here still gate the merge.",
       "matchDatasources": ["github-releases"],
       "matchDepNames": ["/^aida-core\\//"],
       "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "0 days",
       "automerge": true,
       "automergeType": "pr"
     }

--- a/scripts/validate-marketplace.test.ts
+++ b/scripts/validate-marketplace.test.ts
@@ -7,7 +7,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { adr0003, adr0005, isValidGitHubSlug } from "./validate-marketplace.js";
+import { adr0003, adr0005, adr0006, isValidGitHubSlug } from "./validate-marketplace.js";
 import type { Marketplace, Plugin } from "./marketplace-types.js";
 
 function baseMarketplace(): Marketplace {
@@ -206,5 +206,92 @@ describe("ADR-0005 rule (slug identity, no email, no owner.url)", () => {
     );
     const findings = adr0005.check(m);
     assert.equal(findings.filter((f) => f.status === "FAIL").length, 0);
+  });
+});
+
+describe("ADR-0006 rule (semver-tag refs)", () => {
+  it("passes for a v-prefixed semver tag", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ source: { source: "github", repo: "aida-core/example-plugin", ref: "v1.4.6" } }));
+    const findings = adr0006.check(m);
+    assert.equal(findings.filter((f) => f.status === "FAIL").length, 0);
+    assert.equal(findings.filter((f) => f.status === "OK").length, 1);
+  });
+
+  it("passes for a bare semver tag (no v prefix)", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ source: { source: "github", repo: "aida-core/example-plugin", ref: "1.4.6" } }));
+    const findings = adr0006.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(findings.length, 0);
+  });
+
+  it("fails on a branch name", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ source: { source: "github", repo: "aida-core/example-plugin", ref: "main" } }));
+    const fails = adr0006.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /not a semver tag/);
+  });
+
+  it("fails on a 40-char commit SHA", () => {
+    const m = baseMarketplace();
+    m.plugins.push(
+      basePlugin({
+        source: { source: "github", repo: "aida-core/example-plugin", ref: "a1b2c3d4e5f6789012345678901234567890abcd" },
+      }),
+    );
+    const fails = adr0006.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+  });
+
+  it("fails on a non-semver tag", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ source: { source: "github", repo: "aida-core/example-plugin", ref: "release-2024-01" } }));
+    const fails = adr0006.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+  });
+
+  it("fails on a pre-release tag", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ source: { source: "github", repo: "aida-core/example-plugin", ref: "v1.2.3-rc1" } }));
+    const fails = adr0006.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /pre-release/);
+  });
+
+  it("fails on a build-metadata tag", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ source: { source: "github", repo: "aida-core/example-plugin", ref: "v1.2.3+build.5" } }));
+    const fails = adr0006.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+  });
+
+  it("fails on a two-segment version", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ source: { source: "github", repo: "aida-core/example-plugin", ref: "v1.2" } }));
+    const fails = adr0006.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+  });
+
+  it("fails on a missing ref", () => {
+    const m = baseMarketplace();
+    const plugin = basePlugin();
+    (plugin.source as { ref?: unknown }).ref = undefined;
+    m.plugins.push(plugin);
+    const fails = adr0006.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /required/);
+  });
+
+  it("skips non-github sources", () => {
+    const m = baseMarketplace();
+    m.plugins.push(
+      basePlugin({
+        source: { source: "npm", repo: "some-pkg", ref: "1.0.0" } as Plugin["source"],
+      }),
+    );
+    const findings = adr0006.check(m);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].status, "SKIP");
   });
 });

--- a/scripts/validate-marketplace.ts
+++ b/scripts/validate-marketplace.ts
@@ -24,7 +24,7 @@ import type { Marketplace, Plugin } from "./marketplace-types.js";
 
 // --- Types ---
 
-export type FindingStatus = "OK" | "FAIL";
+export type FindingStatus = "OK" | "FAIL" | "SKIP";
 
 export interface Finding {
   /** ADR identifier, e.g. "ADR-0003". */
@@ -216,26 +216,88 @@ export const adr0005: Rule = {
   },
 };
 
+// --- Rule: ADR-0006 (semver-tag refs) ---
+
+const SEMVER_TAG_RE = /^v?\d+\.\d+\.\d+$/;
+
+export const adr0006: Rule = {
+  id: "ADR-0006",
+  title: "Plugin source.ref must be a semver tag (v?X.Y.Z)",
+  check(marketplace) {
+    const findings: Finding[] = [];
+    marketplace.plugins.forEach((plugin, i) => {
+      const ctx = pluginContext(plugin, i);
+
+      // Rule scope: github sources only. Non-github sources are skipped.
+      if (plugin.source?.source !== "github") {
+        findings.push({
+          rule: "ADR-0006",
+          status: "SKIP",
+          context: ctx,
+          message: `source.source="${plugin.source?.source ?? "(missing)"}" — rule applies to github sources only`,
+        });
+        return;
+      }
+
+      const ref = plugin.source.ref;
+      if (typeof ref !== "string" || ref.length === 0) {
+        findings.push({
+          rule: "ADR-0006",
+          status: "FAIL",
+          context: ctx,
+          message: "`source.ref` is required and must be a non-empty string.",
+        });
+        return;
+      }
+
+      if (!SEMVER_TAG_RE.test(ref)) {
+        findings.push({
+          rule: "ADR-0006",
+          status: "FAIL",
+          context: ctx,
+          message:
+            `\`source.ref\` "${ref}" is not a semver tag. ` +
+            "Expected `v?\\d+\\.\\d+\\.\\d+`; branches, SHAs, non-semver tags, " +
+            "and pre-release tags are forbidden.",
+        });
+        return;
+      }
+
+      findings.push({
+        rule: "ADR-0006",
+        status: "OK",
+        context: ctx,
+        message: `source.ref "${ref}" is a valid semver tag`,
+      });
+    });
+    return findings;
+  },
+};
+
 // --- Registry ---
 
-export const RULES: readonly Rule[] = [adr0003, adr0005] as const;
+export const RULES: readonly Rule[] = [adr0003, adr0005, adr0006] as const;
 
 // --- Reporter ---
 
 function formatFinding(f: Finding): string {
-  const symbol = f.status === "OK" ? "✓" : "✗";
+  const symbol = f.status === "OK" ? "✓" : f.status === "FAIL" ? "✗" : "-";
   return `[${f.rule}] ${symbol} ${f.context}: ${f.message}`;
 }
 
 export function report(findings: readonly Finding[]): number {
   let failCount = 0;
   let okCount = 0;
+  let skipCount = 0;
 
   for (const f of findings) {
     const line = formatFinding(f);
     if (f.status === "FAIL") {
       failCount += 1;
       console.error(line);
+    } else if (f.status === "SKIP") {
+      skipCount += 1;
+      console.log(line);
     } else {
       okCount += 1;
       console.log(line);
@@ -243,7 +305,9 @@ export function report(findings: readonly Finding[]): number {
   }
 
   console.log("");
-  console.log(`Validator summary: ${okCount} passing, ${failCount} failing.`);
+  console.log(
+    `Validator summary: ${okCount} passing, ${failCount} failing, ${skipCount} skipped.`,
+  );
   if (failCount > 0) {
     console.error(
       "Failed checks cite ADR numbers. See docs/adr/<NNNN>-*.md for the rationale " +


### PR DESCRIPTION
## Summary

Implements the rule called for by #43 and bundles a small Renovate config tweak.

### Validator change (ADR-0006)

Every github-source plugin's `source.ref` must match `^v?\d+\.\d+\.\d+\$`. Forbidden:

- Branch names (`main`, `develop`, etc.)
- Commit SHAs (40-char hex)
- Non-semver tags (`release-2024-01`, `stable`)
- Pre-release tags (`v1.2.3-rc1`)
- Build-metadata tags (`v1.2.3+build.5`)

Non-github sources are SKIPPED — rule applies to github refs only.

Also adds **`SKIP`** to the validator's finding status (alongside `OK`/`FAIL`) for rules that don't apply to a given entry. Reporter now surfaces the skipped count: \`Validator summary: 4 passing, 0 failing, 0 skipped.\`

### Renovate change (bundled)

`renovate.json` now overrides the org-wide \`minimumReleaseAge: \"14 days\"\` to \`0 days\` for \`aida-core/*\` updates. The 14-day gate protects against compromised external dependencies; for our own plugins it's just delay. CI checks still gate the auto-merge.

## What's included

| File | What |
| --- | --- |
| \`docs/adr/0006-semver-tag-refs.md\` | New ADR, Accepted |
| \`docs/adr/README.md\` | Index updated |
| \`scripts/validate-marketplace.ts\` | New \`adr0006\` rule + \`SKIP\` status + reporter update |
| \`scripts/validate-marketplace.test.ts\` | 10 new unit tests |
| \`renovate.json\` | Override 14-day gate for \`aida-core/*\` |
| \`CHANGELOG.md\` | Entries for both |

## Local verification

- \`npm run typecheck\` ✓
- \`npm test\` ✓ (35/35, was 25/25)
- \`npm run validate\` ✓ — 4 passing, 0 failing, 0 skipped on current manifest

## Closes

- Closes #43 — require semver-tag refs (no branches/SHAs)

## Test plan

- [x] Local typecheck + tests + validator pass
- [ ] CI: TypeScript + Lint + No AI Co-Authors + Changelog all green
- [ ] Spot-check: temporarily set \`ref\` to \`\"main\"\` locally, confirm validator fails with ADR-0006 message