### PR TITLE
feat(validator): closed category allow-list (ADR-0007)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- ADR-0007: closed allow-list for plugin categories
+  (`core`, `workflow`, `infrastructure`, `language`, `integration`,
+  `domain`, `productivity`, `security`, `observability`). Adding a
+  new category requires an ADR amendment + validator update in the
+  same PR. Filed from #45.
+- Validator rule `[ADR-0007]` enforcing the above. Failure
+  messages list the allowed set and point at the ADR amendment
+  process.
 - ADR-0006: plugin `source.ref` values must be semver tags
   (`v?\d+\.\d+\.\d+`). Branches, SHAs, non-semver tags, and
   pre-release/build-metadata tags are all forbidden. Filed from #43.

--- a/docs/adr/0007-category-allow-list.md
+++ b/docs/adr/0007-category-allow-list.md
@@ -1,0 +1,138 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0007: Closed allow-list for plugin categories
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Filed from:** [#45](https://github.com/aida-core/aida-marketplace/issues/45)
+
+## Context
+
+Each entry in `marketplace.json` carries a `category` field. Today the field
+is unconstrained — any string is accepted. Without an allow-list, two failure
+modes accumulate as the catalog grows:
+
+1. **Vocabulary sprawl.** Contributors invent ad-hoc categories that
+   nearly-but-not-quite match existing ones — `dev-workflow`, `workflows`,
+   `developer-workflow`, `dev_workflow`. Discovery suffers because filtering
+   misses entries that should match.
+2. **Drift between operators.** Upstream and downstream marketplaces end up
+   with divergent vocabularies for the same kinds of plugins. Sharing
+   plugins across catalogs requires reading minds.
+
+A closed allow-list, enforced by the validator and amended via ADR, solves
+both. New categories become deliberate additions, not accidents.
+
+## Considered options
+
+1. **Closed set, opinionated** — enumerate the categories upstream considers
+   canonical; the validator rejects anything else.
+   - Pros: prevents sprawl; forces conscious decisions; sets a vocabulary
+     downstream marketplaces can adopt.
+   - Cons: extending the set requires an ADR + validator change.
+
+2. **Free-form** — keep current behavior; any string is acceptable.
+   - Pros: zero friction.
+   - Cons: all the sprawl and drift failure modes above; catalog vocabulary
+     degrades over time without a forcing function.
+
+3. **Hierarchical** — categories are `top/sub` (e.g.,
+   `infrastructure/iac`, `infrastructure/observability`).
+   - Pros: rich taxonomy; finer discovery.
+   - Cons: overkill for a catalog this size; sub-categories proliferate even
+     faster than flat ones; tooling has to parse the path.
+
+## Decision
+
+Adopt **option 1: closed allow-list**.
+
+### Initial set (9 categories)
+
+| Category         | Meaning                                                                       | Example                                    |
+| ---------------- | ----------------------------------------------------------------------------- | ------------------------------------------ |
+| `core`           | Foundational, framework-level plugins                                         | aida-core                                  |
+| `workflow`       | Opinionated workflows for specific development practices                      | TDD enforcement, code-review automation    |
+| `infrastructure` | IaC, deployment, provisioning, ops tooling                                    | terraform, pulumi                          |
+| `language`       | Tooling specific to a programming language                                    | Go linter, Python formatter, TS bundler    |
+| `integration`    | Adapters to third-party services                                              | Slack, Notion, Linear, GitHub Actions      |
+| `domain`         | Knowledge or capability specific to a problem area                            | contests-guidebook, finance-knowledge      |
+| `productivity`   | Personal effectiveness tooling                                                | note-taking, task tracking, knowledge mgmt |
+| `security`       | Authentication, authorization, vulnerability scanning, compliance             | OAuth helpers, dependency audits           |
+| `observability`  | Logging, metrics, tracing, monitoring                                         | Datadog adapter, OpenTelemetry helpers     |
+
+### Boundary clarifications
+
+A few category pairs sound close enough to need explicit boundaries:
+
+- **`workflow` vs `productivity`** — workflow describes *team/development*
+  practices (TDD, code review, release process). Productivity describes
+  *personal* effectiveness tooling (note-taking, task tracking, focus tools).
+- **`security` vs `domain`** — security is its own discipline with
+  recognizable conventions and gets its own top-level category, even though
+  it is technically a domain. Treat `domain` as the catch-all for
+  application or organization-specific knowledge that doesn't fit elsewhere.
+- **`observability` vs `infrastructure`** — observability is
+  logging/metrics/tracing/monitoring as a discipline. Infrastructure is the
+  provisioning and deployment layer underneath. A plugin that ships an OTel
+  collector config is `observability`; a plugin that provisions monitoring
+  pipelines via IaC is `infrastructure`.
+- **`language` vs `workflow`** — language is tooling tied to a specific
+  programming language regardless of practice. Workflow is the practice
+  applied across languages.
+- **`integration` vs `domain`** — integration is an adapter to an external
+  service (the Slack integration). Domain is knowledge about a problem space
+  (a `support-tickets-guidebook` that uses several integrations).
+
+### Process for adding a new category
+
+Per [#42](https://github.com/aida-core/aida-marketplace/issues/42)'s
+"rule = ADR + check in same PR" policy:
+
+1. Open a PR that amends this ADR's Decision section to add the new category
+   (or writes a superseding ADR if the change is structural).
+2. Update `ALLOWED_CATEGORIES` in `scripts/validate-marketplace.ts` in the
+   same PR.
+3. If a current listing is the first to use the new category, update its
+   `category` field in the same PR.
+
+**Bar for adding a category:** at least one concrete planned listing that
+doesn't fit an existing category. Don't add anticipatory categories — wait
+for real demand. If a category goes unused for an extended period, propose
+removing it.
+
+## Consequences
+
+**Gained:**
+
+- Catalog vocabulary is stable and discoverable.
+- Downstream marketplaces have a documented vocabulary to inherit or
+  consciously diverge from.
+- The validator catches typos and ad-hoc inventions at PR time.
+- New categories are deliberate decisions with rationale recorded in the
+  amending PR.
+
+**Accepted costs:**
+
+- Listing a plugin in a category that doesn't yet exist requires an ADR
+  amendment first. Small friction, deliberate.
+- The current allow-list reflects upstream's anticipated taxonomy.
+  Downstream marketplaces with different audiences (e.g., a finance-focused
+  marketplace might want `compliance` as its own top-level category) can
+  fork the ADR or override locally in their own validator.
+- A category goes unused if anticipatory choices don't pan out. The
+  remediation (remove the category, possibly re-categorize listings) is
+  cheap.
+
+## Enforcement
+
+Validator rule `[ADR-0007]` (per [ADR-0001](./0001-validator-language.md)):
+
+- Every `plugins[]` entry has a `category` field that is a non-empty string.
+- `category` value is in the allow-list defined above.
+- Failure messages name this ADR and list the allowed categories.
+
+The allow-list is duplicated between this ADR (canonical, with rationale)
+and `scripts/validate-marketplace.ts` (enforcement). Amendments must update
+both in the same PR; the validator drift between the two is itself a
+review-time check.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,3 +37,4 @@ See [`0000-adr-template.md`](./0000-adr-template.md). Copy it, rename, fill in.
 | 0004 | [GitHub App for cross-repo operations](./0004-github-app.md) | Accepted | [#58](https://github.com/aida-core/aida-marketplace/issues/58) |
 | 0005 | [Author and owner identity](./0005-author-and-owner-identity.md) | Accepted | [#59](https://github.com/aida-core/aida-marketplace/issues/59) |
 | 0006 | [Plugin source refs must be semver tags](./0006-semver-tag-refs.md) | Accepted | [#43](https://github.com/aida-core/aida-marketplace/issues/43) |
+| 0007 | [Closed allow-list for plugin categories](./0007-category-allow-list.md) | Accepted | [#45](https://github.com/aida-core/aida-marketplace/issues/45) |

--- a/scripts/validate-marketplace.test.ts
+++ b/scripts/validate-marketplace.test.ts
@@ -7,7 +7,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { adr0003, adr0005, adr0006, isValidGitHubSlug } from "./validate-marketplace.js";
+import { adr0003, adr0005, adr0006, adr0007, isValidGitHubSlug } from "./validate-marketplace.js";
 import type { Marketplace, Plugin } from "./marketplace-types.js";
 
 function baseMarketplace(): Marketplace {
@@ -293,5 +293,76 @@ describe("ADR-0006 rule (semver-tag refs)", () => {
     const findings = adr0006.check(m);
     assert.equal(findings.length, 1);
     assert.equal(findings[0].status, "SKIP");
+  });
+});
+
+describe("ADR-0007 rule (category allow-list)", () => {
+  const ALLOWED = [
+    "core",
+    "workflow",
+    "infrastructure",
+    "language",
+    "integration",
+    "domain",
+    "productivity",
+    "security",
+    "observability",
+  ];
+
+  it("passes for each allowed category", () => {
+    const m = baseMarketplace();
+    for (const cat of ALLOWED) {
+      m.plugins.push(basePlugin({ name: cat, category: cat }));
+    }
+    const fails = adr0007.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 0);
+  });
+
+  it("fails on an ad-hoc category", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ category: "dev-workflow" }));
+    const fails = adr0007.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /not in the allow-list/);
+  });
+
+  it("fails on a near-miss typo", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ category: "workflows" })); // plural — typo
+    const fails = adr0007.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+  });
+
+  it("fails on empty string", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ category: "" }));
+    const fails = adr0007.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /required/);
+  });
+
+  it("fails on missing category", () => {
+    const m = baseMarketplace();
+    const p = basePlugin();
+    (p as { category?: unknown }).category = undefined;
+    m.plugins.push(p);
+    const fails = adr0007.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+  });
+
+  it("failure message lists the allow-list", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ category: "bogus" }));
+    const fails = adr0007.check(m).filter((f) => f.status === "FAIL");
+    assert.match(fails[0].message, /core/);
+    assert.match(fails[0].message, /security/);
+    assert.match(fails[0].message, /observability/);
+  });
+
+  it("failure message points to the ADR amendment process", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin({ category: "bogus" }));
+    const fails = adr0007.check(m).filter((f) => f.status === "FAIL");
+    assert.match(fails[0].message, /ADR amendment/);
   });
 });

--- a/scripts/validate-marketplace.ts
+++ b/scripts/validate-marketplace.ts
@@ -274,9 +274,67 @@ export const adr0006: Rule = {
   },
 };
 
+// --- Rule: ADR-0007 (closed category allow-list) ---
+
+// The canonical list with rationale lives in docs/adr/0007-category-allow-list.md.
+// Amendments must update both this set and the ADR in the same PR.
+const ALLOWED_CATEGORIES: ReadonlySet<string> = new Set([
+  "core",
+  "workflow",
+  "infrastructure",
+  "language",
+  "integration",
+  "domain",
+  "productivity",
+  "security",
+  "observability",
+]);
+
+export const adr0007: Rule = {
+  id: "ADR-0007",
+  title: "Plugin category must be in the closed allow-list",
+  check(marketplace) {
+    const findings: Finding[] = [];
+    marketplace.plugins.forEach((plugin, i) => {
+      const ctx = pluginContext(plugin, i);
+
+      if (typeof plugin.category !== "string" || plugin.category.length === 0) {
+        findings.push({
+          rule: "ADR-0007",
+          status: "FAIL",
+          context: ctx,
+          message: "`category` is required and must be a non-empty string.",
+        });
+        return;
+      }
+
+      if (!ALLOWED_CATEGORIES.has(plugin.category)) {
+        const allowed = Array.from(ALLOWED_CATEGORIES).sort().join(", ");
+        findings.push({
+          rule: "ADR-0007",
+          status: "FAIL",
+          context: ctx,
+          message:
+            `category "${plugin.category}" is not in the allow-list. ` +
+            `Allowed: ${allowed}. Adding a new category requires an ADR amendment.`,
+        });
+        return;
+      }
+
+      findings.push({
+        rule: "ADR-0007",
+        status: "OK",
+        context: ctx,
+        message: `category "${plugin.category}" is in the allow-list`,
+      });
+    });
+    return findings;
+  },
+};
+
 // --- Registry ---
 
-export const RULES: readonly Rule[] = [adr0003, adr0005, adr0006] as const;
+export const RULES: readonly Rule[] = [adr0003, adr0005, adr0006, adr0007] as const;
 
 // --- Reporter ---
 


### PR DESCRIPTION
## Summary

Implements the rule called for by #45: every plugin's \`category\` field must draw from a closed set of 9 categories. Adding a new category requires an ADR amendment + validator update in the same PR, per #42's "rule = ADR + check in same PR" policy.

## Initial category set

| Category | What it's for |
| --- | --- |
| \`core\` | Foundational, framework-level plugins |
| \`workflow\` | Opinionated workflows for specific development practices |
| \`infrastructure\` | IaC, deployment, provisioning, ops tooling |
| \`language\` | Tooling specific to a programming language |
| \`integration\` | Adapters to third-party services |
| \`domain\` | Knowledge or capability for a problem area |
| \`productivity\` | Personal effectiveness tooling |
| \`security\` | Authentication, scanning, compliance |
| \`observability\` | Logging, metrics, tracing, monitoring |

The ADR includes boundary clarifications for similar pairs (workflow vs productivity, security vs domain, observability vs infrastructure, etc.) and the process for adding new categories.

## What's included

- \`docs/adr/0007-category-allow-list.md\` — full ADR with rationale and amendment process
- \`docs/adr/README.md\` — index updated
- \`scripts/validate-marketplace.ts\` — new \`adr0007\` rule; registry now runs 4 rules
- \`scripts/validate-marketplace.test.ts\` — 7 new tests
- \`CHANGELOG.md\` — entry

## Local verification

- \`npm run typecheck\` ✓
- \`npm test\` ✓ (42/42, was 35/35)
- \`npm run validate\` ✓ — 5 passing, 0 failing on current manifest

## Closes

- Closes #45 — closed allow-list for plugin categories

## Test plan

- [x] Local typecheck + tests + validator pass
- [ ] CI green
- [ ] Spot-check: temporarily set the aida-core entry's category to \`"dev-workflow"\` locally, confirm validator fails with the allow-list listed in the message