### PR TITLE
feat: JSON Schema as canonical structural definition (ADR-0008)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/aida-core/aida-marketplace/main/schemas/marketplace.schema.json",
   "name": "aida",
   "version": "0.2.0",
   "description": "AIDA - Agentic Intelligence Digital Assistant. Foundation plugins for extending Claude Code.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- ADR-0008: JSON Schema is the canonical structural definition of
+  `marketplace.json`. Filed from #50. Establishes a two-layer model
+  — schema for structural enforcement (types, required fields,
+  enums, patterns), validator for cross-field semantics and
+  ADR-traceable failure messages.
+- `schemas/marketplace.schema.json` — JSON Schema draft-07 for the
+  manifest. Mirrors the value-level constraints from ADRs 0003,
+  0005, 0006, 0007.
+- `$schema` field in `.claude-plugin/marketplace.json` pointing
+  at the canonical schema URL. IDEs pick this up automatically
+  for autocomplete and inline structural validation.
+- Schema validation runs in the existing validator before the
+  semantic rules. Structural failures exit before semantic rules
+  run; their error paths point at the failing field
+  (e.g., `/plugins/0/category`).
+- `ajv` (v8) as a devDependency for schema validation.
+- 12 new unit tests covering the schema layer.
+- Documentation noting that the companion frontmatter schema
+  lives at `aida-core/aida-core-plugin/.frontmatter-schema.json`
+  and is referenced (not vendored) to avoid drift.
 - ADR-0007: closed allow-list for plugin categories
   (`core`, `workflow`, `infrastructure`, `language`, `integration`,
   `domain`, `productivity`, `security`, `observability`). Adding a

--- a/docs/adr/0008-json-schemas.md
+++ b/docs/adr/0008-json-schemas.md
@@ -1,0 +1,131 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0008: JSON Schema as the canonical structural definition
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Filed from:** [#50](https://github.com/aida-core/aida-marketplace/issues/50)
+
+## Context
+
+ADRs [0003](./0003-marketplace-entry-kinds.md), [0005](./0005-author-and-owner-identity.md),
+[0006](./0006-semver-tag-refs.md), and [0007](./0007-category-allow-list.md) establish
+the manifest's structural and value-level rules. Their enforcement lives in the
+TypeScript validator. That's the operational gate in CI.
+
+What the validator does *not* give us:
+
+- **IDE support.** Contributors editing `.claude-plugin/marketplace.json` don't get
+  autocomplete or inline structural errors until they push and CI runs.
+- **Cross-tool reuse.** Other languages (Python, Go, Ruby) and other tools
+  (linters, dashboards, downstream marketplaces) can't validate the manifest
+  without running our TS code.
+- **A machine-readable spec.** The valid shape is implicit in the TS types
+  and the rule list. There's no single document a contributor can read to
+  understand what's expected.
+
+JSON Schema is the obvious answer to all three.
+
+The companion frontmatter schema for AIDA markdown files already exists at
+[`aida-core/aida-core-plugin/.frontmatter-schema.json`](https://github.com/aida-core/aida-core-plugin/blob/main/.frontmatter-schema.json)
+and is mature. We reference that schema rather than fork it, to avoid drift.
+
+## Considered options
+
+1. **Hand-maintained schema + validator** — keep the validator (semantic rules)
+   and add a schema file that mirrors structural constraints. Both run in CI;
+   each PR that changes one must update the other.
+   - Pros: low friction; clear separation (schema for structure, validator
+     for cross-field semantics); IDE picks up the schema automatically.
+   - Cons: drift risk between schema and validator; reviewers must remember
+     to update both.
+
+2. **Generate the schema from validator code** — single source of truth
+   in the validator; schema is a build artifact.
+   - Pros: no drift possible.
+   - Cons: schema generation tooling adds dependency; cross-field rules
+     (e.g., ADR-0003's kind <-> suffix match) don't fit JSON Schema cleanly,
+     so the generated schema would only partially express the rules anyway.
+
+3. **Generate the validator from the schema** — single source of truth in
+   the schema; validator dispatches based on schema + adds cross-field
+   semantic rules on top.
+   - Pros: schema-first; ajv already supports runtime validation.
+   - Cons: rewrite of existing validator; cross-field rules still live
+     outside the schema; bigger move than the value justifies.
+
+4. **Schema alone, no separate validator** — drop the per-rule TypeScript
+   validator in favor of pure JSON Schema validation.
+   - Pros: simplest.
+   - Cons: cross-field rules (kind <-> suffix matching, SKIP semantics for
+     non-github sources) can't be expressed in JSON Schema; semantic
+     failure messages with ADR refs disappear.
+
+## Decision
+
+Adopt **option 1: hand-maintained schema + validator**, with the schema
+covering single-field structural constraints and the validator covering
+cross-field semantics and ADR-traceable failure messages.
+
+### Layering
+
+- `schemas/marketplace.schema.json` is the **structural** definition.
+  It expresses: required fields, types, enums, patterns, forbidden additional
+  properties. IDE tools pick it up via the manifest's `$schema` pointer.
+- `scripts/validate-marketplace.ts` is the **semantic** layer.
+  It runs schema validation first; if structurally invalid, it reports the
+  schema errors and exits. If structurally valid, it runs the semantic rules
+  (ADR-0003 cross-field, ADR-0005 forbidden-property and slug, ADR-0006
+  semver + SKIP semantics, ADR-0007 closed allow-list).
+- Both must be updated in the same PR when rules change, per
+  [#42](https://github.com/aida-core/aida-marketplace/issues/42)'s
+  "rule = ADR + check in same PR" policy. The CHANGELOG entry surfaces
+  drift in code review.
+
+### Markdown frontmatter
+
+The companion schema for markdown frontmatter lives upstream in
+[`aida-core/aida-core-plugin/.frontmatter-schema.json`](https://github.com/aida-core/aida-core-plugin/blob/main/.frontmatter-schema.json).
+This marketplace **references** that schema rather than vendoring a copy.
+Downstream consumers (the eventual Python frontmatter validator in
+[#54](https://github.com/aida-core/aida-marketplace/issues/54), plugin
+scaffolding in aida-core-plugin, IDE plugins) should also reference the
+upstream URL. Vendoring is a drift trap.
+
+## Consequences
+
+**Gained:**
+
+- IDE autocomplete and inline structural errors for anyone editing
+  `marketplace.json`.
+- A machine-readable spec consumable by tools outside the validator's TS
+  runtime.
+- Schema-driven structural errors with field paths (e.g.,
+  `/plugins/0/category: "dev-workflow" is not one of [...]`), separate from
+  semantic ADR-traceable errors.
+
+**Accepted costs:**
+
+- Two artifacts (schema + validator) describe overlapping constraints.
+  Drift risk is real but bounded by the same-PR convention plus CI gating
+  both gates on every change.
+- `ajv` is added as a devDependency. Common, well-maintained, ~600KB; no
+  runtime impact since the validator only runs in CI.
+- Cross-field semantic rules (e.g., kind <-> suffix match) can't be
+  expressed in the schema. The validator stays responsible for those.
+
+## Enforcement
+
+- `schemas/marketplace.schema.json` is the canonical structural definition.
+- `scripts/validate-marketplace.ts` loads the schema, runs `ajv` structural
+  validation first; on failure, prints schema errors and exits with code 1
+  before running semantic rules.
+- The manifest carries a `$schema` field pointing at the local schema so
+  IDEs pick it up automatically.
+- Frontmatter schema validation (when [#54](https://github.com/aida-core/aida-marketplace/issues/54)
+  lands) references the upstream schema by URL, not a vendored copy.
+
+When a rule's structural shape changes (e.g., a new ADR alters the manifest),
+the PR MUST update both the schema and the validator rule. CHANGELOG entries
+calling out only one of the two are a review-time smell.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,4 @@ See [`0000-adr-template.md`](./0000-adr-template.md). Copy it, rename, fill in.
 | 0005 | [Author and owner identity](./0005-author-and-owner-identity.md) | Accepted | [#59](https://github.com/aida-core/aida-marketplace/issues/59) |
 | 0006 | [Plugin source refs must be semver tags](./0006-semver-tag-refs.md) | Accepted | [#43](https://github.com/aida-core/aida-marketplace/issues/43) |
 | 0007 | [Closed allow-list for plugin categories](./0007-category-allow-list.md) | Accepted | [#45](https://github.com/aida-core/aida-marketplace/issues/45) |
+| 0008 | [JSON Schema as the canonical structural definition](./0008-json-schemas.md) | Accepted | [#50](https://github.com/aida-core/aida-marketplace/issues/50) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "ajv": "^8.20.0",
         "tsx": "^4.7.0",
         "typescript": "^5.4.0"
       },
@@ -468,6 +469,23 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -510,6 +528,30 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -536,6 +578,23 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "ajv": "^8.20.0",
     "tsx": "^4.7.0",
     "typescript": "^5.4.0"
   }

--- a/schemas/marketplace.schema.json
+++ b/schemas/marketplace.schema.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/aida-core/aida-marketplace/blob/main/schemas/marketplace.schema.json",
+  "title": "AIDA Marketplace Manifest",
+  "description": "Structural schema for `.claude-plugin/marketplace.json`. Mirrors the constraints enforced by the TypeScript validator (see scripts/validate-marketplace.ts). When semantic constraints (e.g., kind <-> repo suffix matching) require cross-field reasoning that JSON Schema can't easily express, those checks live in the validator, not here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "version", "description", "owner", "plugins"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional pointer to this schema for IDE integration."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Marketplace identifier."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Marketplace version (semver X.Y.Z, no v prefix)."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$",
+          "description": "GitHub slug (org or user) that owns the marketplace. Per ADR-0005; email and url are forbidden."
+        }
+      }
+    },
+    "plugins": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/Plugin" }
+    }
+  },
+  "definitions": {
+    "Plugin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "kind",
+        "source",
+        "description",
+        "version",
+        "category",
+        "author",
+        "tags"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["plugin", "guidebook"],
+          "description": "Marketplace entry kind. Per ADR-0003; source.repo suffix must match (cross-field rule enforced by the validator)."
+        },
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "repo", "ref"],
+          "properties": {
+            "source": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Source provider (e.g., \"github\")."
+            },
+            "repo": {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$",
+              "description": "owner/repo form."
+            },
+            "ref": {
+              "type": "string",
+              "pattern": "^v?\\d+\\.\\d+\\.\\d+$",
+              "description": "Semver tag (optional v prefix). Per ADR-0006; branches, SHAs, pre-release tags, and build-metadata tags are forbidden."
+            }
+          }
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "description": "Plugin semver (no v prefix)."
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "core",
+            "workflow",
+            "infrastructure",
+            "language",
+            "integration",
+            "domain",
+            "productivity",
+            "security",
+            "observability"
+          ],
+          "description": "Per ADR-0007; adding a category requires an ADR amendment + validator update."
+        },
+        "homepage": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional. URI to the plugin's homepage."
+        },
+        "author": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$",
+              "description": "GitHub slug (org or user). Per ADR-0005; email is forbidden."
+            }
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-marketplace.test.ts
+++ b/scripts/validate-marketplace.test.ts
@@ -6,9 +6,24 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-import { adr0003, adr0005, adr0006, adr0007, isValidGitHubSlug } from "./validate-marketplace.js";
+import {
+  adr0003,
+  adr0005,
+  adr0006,
+  adr0007,
+  isValidGitHubSlug,
+  validateSchema,
+} from "./validate-marketplace.js";
 import type { Marketplace, Plugin } from "./marketplace-types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCHEMA: unknown = JSON.parse(
+  readFileSync(resolve(__dirname, "..", "schemas", "marketplace.schema.json"), "utf-8"),
+);
 
 function baseMarketplace(): Marketplace {
   return {
@@ -364,5 +379,115 @@ describe("ADR-0007 rule (category allow-list)", () => {
     m.plugins.push(basePlugin({ category: "bogus" }));
     const fails = adr0007.check(m).filter((f) => f.status === "FAIL");
     assert.match(fails[0].message, /ADR amendment/);
+  });
+});
+
+describe("Schema validation (ADR-0008)", () => {
+  function validManifest(): Record<string, unknown> {
+    return {
+      name: "test",
+      version: "0.1.0",
+      description: "A test marketplace.",
+      owner: { name: "aida-core" },
+      plugins: [
+        {
+          name: "example",
+          kind: "plugin",
+          source: { source: "github", repo: "aida-core/example-plugin", ref: "v1.0.0" },
+          description: "An example.",
+          version: "1.0.0",
+          category: "core",
+          author: { name: "aida-core" },
+          tags: ["example"],
+        },
+      ],
+    };
+  }
+
+  it("accepts a clean manifest", () => {
+    const result = validateSchema(validManifest(), SCHEMA);
+    assert.equal(result.valid, true);
+    assert.equal(result.errors.length, 0);
+  });
+
+  it("accepts a manifest with optional $schema field", () => {
+    const m = validManifest();
+    m.$schema = "https://example.com/schema.json";
+    const result = validateSchema(m, SCHEMA);
+    assert.equal(result.valid, true);
+  });
+
+  it("rejects manifest missing required `owner`", () => {
+    const m = validManifest();
+    delete m.owner;
+    const result = validateSchema(m, SCHEMA);
+    assert.equal(result.valid, false);
+  });
+
+  it("rejects manifest missing required `plugins`", () => {
+    const m = validManifest();
+    delete m.plugins;
+    const result = validateSchema(m, SCHEMA);
+    assert.equal(result.valid, false);
+  });
+
+  it("rejects owner with forbidden `email` property", () => {
+    const m = validManifest();
+    (m.owner as Record<string, unknown>).email = "ops@example.com";
+    const result = validateSchema(m, SCHEMA);
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => /additionalProp/i.test(e.message ?? "") || /email/.test(JSON.stringify(e.params))));
+  });
+
+  it("rejects owner.name that isn't a valid GitHub slug", () => {
+    const m = validManifest();
+    (m.owner as Record<string, unknown>).name = "foo bar"; // space invalid
+    const result = validateSchema(m, SCHEMA);
+    assert.equal(result.valid, false);
+  });
+
+  it("rejects plugin with invalid `kind` enum value", () => {
+    const m = validManifest();
+    ((m.plugins as Array<Record<string, unknown>>)[0]).kind = "playbook";
+    const result = validateSchema(m, SCHEMA);
+    assert.equal(result.valid, false);
+  });
+
+  it("rejects plugin with category not in the allow-list", () => {
+    const m = validManifest();
+    ((m.plugins as Array<Record<string, unknown>>)[0]).category = "dev-workflow";
+    const result = validateSchema(m, SCHEMA);
+    assert.equal(result.valid, false);
+  });
+
+  it("rejects plugin with source.ref that isn't semver", () => {
+    const m = validManifest();
+    const source = ((m.plugins as Array<Record<string, unknown>>)[0]).source as Record<string, unknown>;
+    source.ref = "main";
+    const result = validateSchema(m, SCHEMA);
+    assert.equal(result.valid, false);
+  });
+
+  it("rejects plugin missing required `kind`", () => {
+    const m = validManifest();
+    delete ((m.plugins as Array<Record<string, unknown>>)[0]).kind;
+    const result = validateSchema(m, SCHEMA);
+    assert.equal(result.valid, false);
+  });
+
+  it("rejects wrong type on version (number instead of string)", () => {
+    const m = validManifest();
+    m.version = 1 as unknown as string;
+    const result = validateSchema(m, SCHEMA);
+    assert.equal(result.valid, false);
+  });
+
+  it("error paths point to the failing field", () => {
+    const m = validManifest();
+    ((m.plugins as Array<Record<string, unknown>>)[0]).category = "bogus";
+    const result = validateSchema(m, SCHEMA);
+    assert.equal(result.valid, false);
+    const categoryErr = result.errors.find((e) => /category/.test(e.instancePath ?? ""));
+    assert.ok(categoryErr, "expected an error with instancePath containing /category");
   });
 });

--- a/scripts/validate-marketplace.ts
+++ b/scripts/validate-marketplace.ts
@@ -20,6 +20,8 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import Ajv, { type ErrorObject } from "ajv";
+
 import type { Marketplace, Plugin } from "./marketplace-types.js";
 
 // --- Types ---
@@ -336,6 +338,39 @@ export const adr0007: Rule = {
 
 export const RULES: readonly Rule[] = [adr0003, adr0005, adr0006, adr0007] as const;
 
+// --- Schema validation (ADR-0008) ---
+
+interface SchemaResult {
+  valid: boolean;
+  errors: ErrorObject[];
+}
+
+function loadSchema(scriptDir: string): unknown {
+  const root = resolve(scriptDir, "..");
+  const schemaPath = resolve(root, "schemas", "marketplace.schema.json");
+  return JSON.parse(readFileSync(schemaPath, "utf-8"));
+}
+
+export function validateSchema(marketplace: unknown, schema: unknown): SchemaResult {
+  // `strict: false` because we use `description` fields for documentation that
+  // strict mode would warn on.
+  // The `as unknown as new ...` cast handles ajv's default-export interop quirk
+  // under Node16/ESM, where TS sees the namespace rather than the class itself.
+  const AjvCtor = Ajv as unknown as new (opts?: object) => {
+    compile: (schema: object) => ((data: unknown) => boolean) & { errors?: ErrorObject[] | null };
+  };
+  const ajv = new AjvCtor({ allErrors: true, strict: false });
+  const validate = ajv.compile(schema as object);
+  const ok = validate(marketplace);
+  return { valid: !!ok, errors: validate.errors ?? [] };
+}
+
+function formatSchemaError(err: ErrorObject): string {
+  const path = err.instancePath || "(root)";
+  const detail = err.params ? ` ${JSON.stringify(err.params)}` : "";
+  return `[schema] ✗ ${path}: ${err.message ?? "(no message)"}${detail}`;
+}
+
 // --- Reporter ---
 
 function formatFinding(f: Finding): string {
@@ -405,6 +440,27 @@ function main(): void {
     console.error(`[ERROR] ${manifestPath} is not valid JSON: ${(err as Error).message}`);
     process.exit(2);
   }
+
+  // Structural validation first (ADR-0008). If the manifest doesn't conform
+  // to the schema, semantic rules can't run safely — report and exit.
+  let schema: unknown;
+  try {
+    schema = loadSchema(__dirname);
+  } catch (err) {
+    console.error(`[ERROR] could not load marketplace schema: ${(err as Error).message}`);
+    process.exit(2);
+  }
+  const schemaResult = validateSchema(marketplace, schema);
+  if (!schemaResult.valid) {
+    console.error("Schema validation FAILED (per ADR-0008):");
+    for (const err of schemaResult.errors) {
+      console.error("  " + formatSchemaError(err));
+    }
+    console.error("");
+    console.error("Fix structural issues before semantic rules can run.");
+    process.exit(1);
+  }
+  console.log("[schema] ✓ marketplace.json conforms to schemas/marketplace.schema.json");
 
   const findings = runRules(marketplace);
   const failures = report(findings);


### PR DESCRIPTION
## Summary

Closes #50. Establishes a two-layer model for manifest validation:

- **\`schemas/marketplace.schema.json\`** is the structural definition (types, required fields, enums, patterns, forbidden additional properties). IDEs pick it up via the new \`\$schema\` reference in \`marketplace.json\` and surface inline errors as contributors type.
- **\`scripts/validate-marketplace.ts\`** is the semantic layer. It runs schema validation **first**; on structural failure, it prints field-path-anchored errors and exits before semantic rules. Otherwise it runs the four ADR-traced rules (0003, 0005, 0006, 0007).

The schema mirrors value-level constraints. Cross-field rules that JSON Schema can't easily express (kind <-> repo suffix matching, non-github SKIP semantics) stay in the semantic validator.

## What's in this PR

| File | Purpose |
| --- | --- |
| \`schemas/marketplace.schema.json\` | NEW — draft-07 schema for the manifest |
| \`docs/adr/0008-json-schemas.md\` | NEW (Accepted) — rationale, layering, drift mitigation |
| \`docs/adr/README.md\` | Index updated |
| \`.claude-plugin/marketplace.json\` | \`\$schema\` field added |
| \`scripts/validate-marketplace.ts\` | \`validateSchema()\` + schema-first integration in \`main()\` |
| \`scripts/validate-marketplace.test.ts\` | +12 schema tests (54 total now, was 42) |
| \`package.json\` / \`package-lock.json\` | \`ajv\` v8 devDep |
| \`CHANGELOG.md\` | Entries |

## Validator output now

\`\`\`
[schema] ✓ marketplace.json conforms to schemas/marketplace.schema.json
[ADR-0003] ✓ plugins[0] (aida-core): kind=\"plugin\" matches repo suffix
[ADR-0005] ✓ owner: owner.name \"oakensoul\" is a valid GitHub slug
[ADR-0005] ✓ plugins[0] (aida-core): author.name \"aida-core\" is a valid GitHub slug
[ADR-0006] ✓ plugins[0] (aida-core): source.ref \"v1.4.6\" is a valid semver tag
[ADR-0007] ✓ plugins[0] (aida-core): category \"core\" is in the allow-list
\`\`\`

If a structural rule fails, the output is field-path anchored, e.g.:

\`\`\`
[schema] ✗ /plugins/0/category: must be equal to one of the allowed values {\"allowedValues\":[\"core\",\"workflow\",...]}
\`\`\`

## Frontmatter schema (NOT in this PR)

The mature schema at [\`aida-core/aida-core-plugin/.frontmatter-schema.json\`](https://github.com/aida-core/aida-core-plugin/blob/main/.frontmatter-schema.json) is **referenced** (not vendored) per ADR-0008. The Python frontmatter validator filed as #54 will use that URL directly when it lands.

## Local verification

- \`npm run typecheck\` ✓
- \`npm test\` ✓ (54/54)
- \`npm run validate\` ✓ — schema + 5 semantic rules pass on current manifest

## Closes

- Closes #50 — JSON Schemas for marketplace.json (and frontmatter, by reference)