### PR TITLE
feat(validator): aida-config.json existence required (ADR-0009)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: npm test
 
       - name: Validate marketplace.json (per ADR-0001)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run validate
 
       - name: Plugin version check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- ADR-0009: listed plugins must ship
+  `.claude-plugin/aida-config.json` at the pinned `source.ref`.
+  The AIDA foundation plugin (`aida-core/aida-core-plugin`) is
+  exempt — the marketplace's existence is predicated on it being
+  the foundation, so requiring self-conformance would be
+  circular. Filed from #44.
+- Validator rule `[ADR-0009]` enforcing the above. Uses a
+  `RemoteFileChecker` interface (with `gh api` as the default
+  implementation) so tests can run against a mock without
+  network access. SKIPs cleanly when `gh` is unavailable on
+  dev machines.
+- 8 new unit tests covering ADR-0009: foundation exemption,
+  non-github skip, present/missing/error file outcomes, missing
+  ref, and a multi-plugin mixed-outcome scenario.
 - `scripts/validate-frontmatter.py` — validates YAML frontmatter
   on markdown files against the AIDA frontmatter schema. The
   schema is fetched from its canonical upstream location at
@@ -138,6 +152,9 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Changed
 
+- CI: the `Validate marketplace.json` step now receives
+  `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` so ADR-0009 can hit
+  the Contents API for each listed plugin.
 - `renovate.json` now overrides the org-wide
   `minimumReleaseAge: "14 days"` to `0 days` for `aida-core/*`
   source updates. We own those plugins; the 14-day supply-chain

--- a/docs/adr/0009-aida-config-required.md
+++ b/docs/adr/0009-aida-config-required.md
@@ -1,0 +1,127 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0009: Listed plugins must ship `.claude-plugin/aida-config.json`
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Filed from:** [#44](https://github.com/aida-core/aida-marketplace/issues/44)
+
+## Context
+
+The marketplace exists to curate **AIDA-conformant** plugins. Today, nothing
+operationally enforces that a listed plugin actually IS AIDA-conformant —
+anyone could submit a non-AIDA repository and the manifest would happily
+accept it. The closest signal we have is the `-plugin` repo suffix
+(ADR-0003), which is a naming convention, not a structural fact about the
+plugin itself.
+
+A better signal is the presence of `.claude-plugin/aida-config.json` in the
+plugin's source repo. The AIDA scaffolding generator (in
+`aida-core-plugin`) writes this file as part of `init`, and the file is
+required for the plugin to function as an AIDA extension. So:
+
+- **It's a structural fact, not a self-claim.** A `"aida": true` field
+  somewhere can be added by anyone; an `aida-config.json` shipping a real
+  config block has to come from the scaffolder or a deliberate hand-port.
+- **It scales with the framework.** As `aida-config.json` evolves (new
+  fields, schema versions), the marketplace gets free validation that
+  plugins keep pace.
+- **It's verifiable by a single GitHub Contents API call** at the pinned
+  `source.ref` — no need to clone the plugin or parse its contents.
+
+## Considered options
+
+1. **No check** — current state. Listings are taken on faith.
+   - Pros: zero work.
+   - Cons: doesn't operationally enforce the marketplace's reason for existing.
+
+2. **Verify `.claude-plugin/aida-config.json` exists at `source.ref`**
+   for every listed plugin.
+   - Pros: cheap (one API call per plugin per validate run); structural
+     fact, not gameable by self-claim; aligns with the existing ref-existence
+     check pattern in `update-marketplace.ts`.
+   - Cons: requires network access in CI (`gh` CLI + `GITHUB_TOKEN`);
+     private plugins need elevated auth (Enterprise profile per ADR-0002).
+
+3. **Parse and validate `aida-config.json` contents** against a schema.
+   - Pros: catches malformed configs, not just missing files.
+   - Cons: a separate ADR's worth of design (what fields are required?
+     what counts as "valid"?); the contents schema lives upstream in
+     `aida-core-plugin` and changes there shouldn't break this validator.
+
+4. **Require a specific commit SHA in `aida-config.json`** to prove the
+   file came from a real scaffolder run.
+   - Pros: more tamper-resistant.
+   - Cons: forces all scaffolds to carry a synthetic SHA; over-engineered
+     for the threat model (we trust the source-repo owner; this rule is
+     about detecting accidents, not malice).
+
+## Decision
+
+Adopt **option 2: existence check at `source.ref`**.
+
+Specifically:
+
+- For every entry in `plugins[]` where `source.source === "github"`, the
+  validator checks that `.claude-plugin/aida-config.json` exists at the
+  pinned `source.ref` in the plugin's source repo.
+- **Exception:** the AIDA foundation plugin
+  (`aida-core/aida-core-plugin`) is exempt. The marketplace's existence is
+  predicated on it being THE foundation; requiring it to declare
+  conformance to itself is circular.
+- **Non-github sources** are SKIPPED. The rule applies to GitHub refs
+  only; other sources need their own conformance check (TBD).
+- **404** on the Contents API → FAIL with a message naming the missing
+  path and the pinned ref.
+- **200** → OK.
+- **Transient errors** (timeout, 5xx) → FAIL with a clear "could not
+  verify" message. CI should never silently pass an unverified plugin.
+- **`gh` CLI unavailable or unauthenticated locally** → SKIP all per-plugin
+  checks with a notice asking the dev to install/auth gh. CI always has
+  `gh` + `GITHUB_TOKEN`, so this branch only fires on dev machines.
+
+This is *not* a contents check. We only verify file existence. A future
+ADR can layer contents validation on top.
+
+## Consequences
+
+**Gained:**
+
+- A real, structural conformance signal for every listed plugin.
+- The marketplace's curated promise becomes mechanically enforceable.
+- New plugins added without scaffolder usage get caught at PR time.
+- Aligns the marketplace with the AIDA scaffolder's contract.
+
+**Accepted costs:**
+
+- N GitHub API calls per validate run (one per non-foundation,
+  github-sourced plugin). With the current plugin count, this is trivial
+  (~ms per call, well under any rate limit).
+- CI requires `GH_TOKEN` on the validate step. (Already wired for the
+  existing `npm run check` step.)
+- Local dev requires `gh auth login` for a complete validation. Without it,
+  ADR-0009 SKIPs (other rules still run).
+- Private plugins (Enterprise profile per ADR-0002) require a GitHub App
+  token for cross-repo reads (ADR-0004). Upstream's simple profile uses the
+  default `GITHUB_TOKEN`.
+
+## Enforcement
+
+Validator rule `[ADR-0009]` (per [ADR-0001](./0001-validator-language.md)):
+
+- Available + authenticated `gh` CLI required. The rule checks once at the
+  start; if unavailable, it emits a single SKIP notice covering all
+  per-plugin checks (no false FAIL on dev machines without `gh`).
+- For each `plugins[]` entry where `source.source === "github"`:
+  - If `source.repo === "aida-core/aida-core-plugin"`: SKIP (foundation
+    exemption).
+  - Otherwise: `gh api repos/{repo}/contents/.claude-plugin/aida-config.json?ref={ref}`.
+    HTTP 200 → OK; HTTP 404 → FAIL; other errors → FAIL with "could not
+    verify" message.
+- Non-github sources: SKIP.
+- Failure messages cite this ADR.
+
+The rule is implemented with dependency injection (`RemoteFileChecker`
+interface) so tests can run with a mock checker. The default checker
+shells out to `gh api` for production use.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,3 +39,4 @@ See [`0000-adr-template.md`](./0000-adr-template.md). Copy it, rename, fill in.
 | 0006 | [Plugin source refs must be semver tags](./0006-semver-tag-refs.md) | Accepted | [#43](https://github.com/aida-core/aida-marketplace/issues/43) |
 | 0007 | [Closed allow-list for plugin categories](./0007-category-allow-list.md) | Accepted | [#45](https://github.com/aida-core/aida-marketplace/issues/45) |
 | 0008 | [JSON Schema as the canonical structural definition](./0008-json-schemas.md) | Accepted | [#50](https://github.com/aida-core/aida-marketplace/issues/50) |
+| 0009 | [Listed plugins must ship `.claude-plugin/aida-config.json`](./0009-aida-config-required.md) | Accepted | [#44](https://github.com/aida-core/aida-marketplace/issues/44) |

--- a/scripts/validate-marketplace.test.ts
+++ b/scripts/validate-marketplace.test.ts
@@ -16,7 +16,10 @@ import {
   adr0006,
   adr0007,
   isValidGitHubSlug,
+  makeAdr0009Rule,
   validateSchema,
+  type FileCheckResult,
+  type RemoteFileChecker,
 } from "./validate-marketplace.js";
 import type { Marketplace, Plugin } from "./marketplace-types.js";
 
@@ -489,5 +492,174 @@ describe("Schema validation (ADR-0008)", () => {
     assert.equal(result.valid, false);
     const categoryErr = result.errors.find((e) => /category/.test(e.instancePath ?? ""));
     assert.ok(categoryErr, "expected an error with instancePath containing /category");
+  });
+});
+
+describe("ADR-0009 rule (aida-config.json existence)", () => {
+  function makeMockChecker(opts: {
+    available?: boolean;
+    files?: Record<string, FileCheckResult>;
+  }): RemoteFileChecker {
+    return {
+      isAvailable: () => opts.available ?? true,
+      checkFile: (repo, ref, path): FileCheckResult => {
+        const key = `${repo}@${ref}:${path}`;
+        return opts.files?.[key] ?? "missing";
+      },
+    };
+  }
+
+  it("emits a single SKIP when the checker is unavailable", () => {
+    const m = baseMarketplace();
+    m.plugins.push(basePlugin());
+    m.plugins.push(basePlugin({ name: "b" }));
+    const rule = makeAdr0009Rule(makeMockChecker({ available: false }));
+    const findings = rule.check(m);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].status, "SKIP");
+    assert.match(findings[0].message, /unavailable/);
+  });
+
+  it("exempts the AIDA foundation plugin", () => {
+    const m = baseMarketplace();
+    m.plugins.push(
+      basePlugin({
+        name: "aida-core",
+        source: { source: "github", repo: "aida-core/aida-core-plugin", ref: "v1.4.6" },
+      }),
+    );
+    const rule = makeAdr0009Rule(makeMockChecker({ available: true, files: {} }));
+    const findings = rule.check(m);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].status, "SKIP");
+    assert.match(findings[0].message, /foundation/);
+  });
+
+  it("skips non-github sources", () => {
+    const m = baseMarketplace();
+    m.plugins.push(
+      basePlugin({
+        source: { source: "npm", repo: "some-pkg", ref: "1.0.0" } as Plugin["source"],
+      }),
+    );
+    const rule = makeAdr0009Rule(makeMockChecker({ available: true, files: {} }));
+    const findings = rule.check(m);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].status, "SKIP");
+  });
+
+  it("passes when aida-config.json is present", () => {
+    const m = baseMarketplace();
+    m.plugins.push(
+      basePlugin({
+        name: "pulumi",
+        source: { source: "github", repo: "aida-core/aida-pulumi-plugin", ref: "v0.9.0" },
+      }),
+    );
+    const rule = makeAdr0009Rule(
+      makeMockChecker({
+        available: true,
+        files: {
+          "aida-core/aida-pulumi-plugin@v0.9.0:.claude-plugin/aida-config.json": "present",
+        },
+      }),
+    );
+    const findings = rule.check(m);
+    const fails = findings.filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 0);
+    assert.equal(findings.filter((f) => f.status === "OK").length, 1);
+  });
+
+  it("fails when aida-config.json is missing (404)", () => {
+    const m = baseMarketplace();
+    m.plugins.push(
+      basePlugin({
+        name: "flow",
+        source: { source: "github", repo: "aida-core/aida-flow-plugin", ref: "v0.1.0" },
+      }),
+    );
+    const rule = makeAdr0009Rule(
+      makeMockChecker({
+        available: true,
+        files: {
+          "aida-core/aida-flow-plugin@v0.1.0:.claude-plugin/aida-config.json": "missing",
+        },
+      }),
+    );
+    const fails = rule.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /HTTP 404/);
+  });
+
+  it("fails on a network/checker error (could not verify)", () => {
+    const m = baseMarketplace();
+    m.plugins.push(
+      basePlugin({
+        name: "flow",
+        source: { source: "github", repo: "aida-core/aida-flow-plugin", ref: "v0.1.0" },
+      }),
+    );
+    const rule = makeAdr0009Rule(
+      makeMockChecker({
+        available: true,
+        files: {
+          "aida-core/aida-flow-plugin@v0.1.0:.claude-plugin/aida-config.json": "error",
+        },
+      }),
+    );
+    const fails = rule.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /could not verify/);
+  });
+
+  it("fails when source.ref is missing", () => {
+    const m = baseMarketplace();
+    const plugin = basePlugin({
+      source: { source: "github", repo: "aida-core/x-plugin", ref: "v1.0.0" },
+    });
+    (plugin.source as { ref?: unknown }).ref = undefined;
+    m.plugins.push(plugin);
+    const rule = makeAdr0009Rule(makeMockChecker({ available: true }));
+    const fails = rule.check(m).filter((f) => f.status === "FAIL");
+    assert.equal(fails.length, 1);
+    assert.match(fails[0].message, /source.ref/);
+  });
+
+  it("handles a multi-plugin manifest with mixed outcomes", () => {
+    const m = baseMarketplace();
+    m.plugins.push(
+      basePlugin({
+        name: "core",
+        source: { source: "github", repo: "aida-core/aida-core-plugin", ref: "v1.4.6" },
+      }),
+    );
+    m.plugins.push(
+      basePlugin({
+        name: "pulumi",
+        source: { source: "github", repo: "aida-core/aida-pulumi-plugin", ref: "v0.9.0" },
+      }),
+    );
+    m.plugins.push(
+      basePlugin({
+        name: "flow",
+        source: { source: "github", repo: "aida-core/aida-flow-plugin", ref: "v0.1.0" },
+      }),
+    );
+    const rule = makeAdr0009Rule(
+      makeMockChecker({
+        available: true,
+        files: {
+          "aida-core/aida-pulumi-plugin@v0.9.0:.claude-plugin/aida-config.json": "present",
+          "aida-core/aida-flow-plugin@v0.1.0:.claude-plugin/aida-config.json": "missing",
+        },
+      }),
+    );
+    const findings = rule.check(m);
+    const skips = findings.filter((f) => f.status === "SKIP");
+    const oks = findings.filter((f) => f.status === "OK");
+    const fails = findings.filter((f) => f.status === "FAIL");
+    assert.equal(skips.length, 1, "foundation is skipped");
+    assert.equal(oks.length, 1, "pulumi has file → OK");
+    assert.equal(fails.length, 1, "flow missing → FAIL");
   });
 });

--- a/scripts/validate-marketplace.ts
+++ b/scripts/validate-marketplace.ts
@@ -16,6 +16,7 @@
 // Each rule's failure messages MUST cite the ADR by id (e.g. `[ADR-0003]`)
 // so contributors can find the rationale without leaving the terminal.
 
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -276,6 +277,56 @@ export const adr0006: Rule = {
   },
 };
 
+// --- Remote file checker (used by ADR-0009) ---
+
+export type FileCheckResult = "present" | "missing" | "error";
+
+export interface RemoteFileChecker {
+  /** Returns true if the checker is ready to make calls (gh auth, network, etc.). */
+  isAvailable(): boolean;
+  /** Check whether a file exists at the given ref in the given GitHub repo. */
+  checkFile(repo: string, ref: string, path: string): FileCheckResult;
+}
+
+/**
+ * Default checker that shells out to `gh api`. Requires `gh` CLI on PATH and
+ * a valid authentication (CI: GITHUB_TOKEN; local: `gh auth login`).
+ */
+export const ghCliChecker: RemoteFileChecker = {
+  isAvailable(): boolean {
+    try {
+      execFileSync("gh", ["auth", "status"], {
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 10_000,
+        encoding: "utf-8",
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  checkFile(repo, ref, path): FileCheckResult {
+    const url = `repos/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`;
+    try {
+      execFileSync("gh", ["api", url], {
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 30_000,
+        encoding: "utf-8",
+      });
+      return "present";
+    } catch (err) {
+      const stderr = (err as { stderr?: Buffer | string }).stderr ?? "";
+      const stderrStr = typeof stderr === "string" ? stderr : stderr.toString();
+      // `gh api` writes the API response to stderr on non-2xx; a 404 includes "HTTP 404"
+      // or '"status":"404"' in the body. Treat both as a clean "missing".
+      if (/HTTP 404\b/.test(stderrStr) || /"status":\s*"404"/.test(stderrStr) || /Not Found/i.test(stderrStr)) {
+        return "missing";
+      }
+      return "error";
+    }
+  },
+};
+
 // --- Rule: ADR-0007 (closed category allow-list) ---
 
 // The canonical list with rationale lives in docs/adr/0007-category-allow-list.md.
@@ -334,9 +385,114 @@ export const adr0007: Rule = {
   },
 };
 
+// --- Rule: ADR-0009 (aida-config.json existence) ---
+
+// The AIDA foundation plugin. Exempt from ADR-0009 because the marketplace's
+// existence is predicated on it being the foundation — requiring it to declare
+// conformance to itself would be circular.
+const FOUNDATION_REPO = "aida-core/aida-core-plugin";
+const AIDA_CONFIG_PATH = ".claude-plugin/aida-config.json";
+
+export function makeAdr0009Rule(checker: RemoteFileChecker): Rule {
+  return {
+    id: "ADR-0009",
+    title: "Listed plugins must ship .claude-plugin/aida-config.json",
+    check(marketplace) {
+      const findings: Finding[] = [];
+
+      // Gate: checker must be available. Without it (e.g., dev machine without
+      // `gh auth login`) we emit a single SKIP notice rather than false-FAIL
+      // every plugin.
+      if (!checker.isAvailable()) {
+        findings.push({
+          rule: "ADR-0009",
+          status: "SKIP",
+          context: "(all plugins)",
+          message:
+            "remote file checker unavailable (e.g., `gh` CLI not installed or " +
+            "not authenticated); install gh and run `gh auth login` to enable " +
+            "ADR-0009 verification.",
+        });
+        return findings;
+      }
+
+      marketplace.plugins.forEach((plugin, i) => {
+        const ctx = pluginContext(plugin, i);
+
+        if (plugin.source?.source !== "github") {
+          findings.push({
+            rule: "ADR-0009",
+            status: "SKIP",
+            context: ctx,
+            message: `source.source="${plugin.source?.source ?? "(missing)"}" — rule applies to github sources only`,
+          });
+          return;
+        }
+
+        if (plugin.source.repo === FOUNDATION_REPO) {
+          findings.push({
+            rule: "ADR-0009",
+            status: "SKIP",
+            context: ctx,
+            message: `${FOUNDATION_REPO} is the AIDA foundation; exempt from ADR-0009`,
+          });
+          return;
+        }
+
+        const ref = plugin.source.ref;
+        if (typeof ref !== "string" || ref.length === 0) {
+          findings.push({
+            rule: "ADR-0009",
+            status: "FAIL",
+            context: ctx,
+            message: "cannot verify aida-config.json: source.ref is missing.",
+          });
+          return;
+        }
+
+        const result = checker.checkFile(plugin.source.repo, ref, AIDA_CONFIG_PATH);
+        if (result === "present") {
+          findings.push({
+            rule: "ADR-0009",
+            status: "OK",
+            context: ctx,
+            message: `${AIDA_CONFIG_PATH} present at ${plugin.source.repo}@${ref}`,
+          });
+          return;
+        }
+        if (result === "missing") {
+          findings.push({
+            rule: "ADR-0009",
+            status: "FAIL",
+            context: ctx,
+            message:
+              `${AIDA_CONFIG_PATH} not found at ${plugin.source.repo}@${ref} (HTTP 404). ` +
+              "Listed plugins must ship an AIDA scaffolding manifest.",
+          });
+          return;
+        }
+        // result === "error"
+        findings.push({
+          rule: "ADR-0009",
+          status: "FAIL",
+          context: ctx,
+          message:
+            `could not verify ${AIDA_CONFIG_PATH} at ${plugin.source.repo}@${ref} ` +
+            "(network or auth error). CI should not silently pass an unverified plugin.",
+        });
+      });
+
+      return findings;
+    },
+  };
+}
+
+/** Default rule instance wired to the real `gh api` checker. */
+export const adr0009: Rule = makeAdr0009Rule(ghCliChecker);
+
 // --- Registry ---
 
-export const RULES: readonly Rule[] = [adr0003, adr0005, adr0006, adr0007] as const;
+export const RULES: readonly Rule[] = [adr0003, adr0005, adr0006, adr0007, adr0009] as const;
 
 // --- Schema validation (ADR-0008) ---
 


### PR DESCRIPTION
## Summary

Closes #44. Listed plugins must ship \`.claude-plugin/aida-config.json\` at the pinned \`source.ref\`. The marketplace exists to curate AIDA-conformant plugins; the file's presence is a **structural fact** (required for the plugin to function as an AIDA extension), not a self-claim.

## Semantics

| Case | Behavior |
| --- | --- |
| \`source.source === \"github\"\` and file present at ref | OK |
| Same, but file missing (HTTP 404) | FAIL with the path + ref in the message |
| Same, but checker error (network / 5xx / auth) | FAIL with \"could not verify\" — CI never silently passes unverified plugins |
| \`source.repo === \"aida-core/aida-core-plugin\"\` (foundation) | SKIP — circular to require self-conformance |
| \`source.source !== \"github\"\` | SKIP — rule applies to github only |
| \`gh\` CLI unavailable or unauthed locally | SKIP **all** with a single notice; other rules still run |

## Implementation: dependency injection

The rule is constructed via \`makeAdr0009Rule(checker: RemoteFileChecker)\`. The default checker (\`ghCliChecker\`) shells out to \`gh api\`. Tests use a synthetic mock — no network access required, no flake.

## Local validator output on the current manifest

\`\`\`
[schema] ✓ marketplace.json conforms to schemas/marketplace.schema.json
[ADR-0003] ✓ plugins[0] (aida-core): kind=\"plugin\" matches repo suffix
[ADR-0005] ✓ owner: owner.name \"oakensoul\" is a valid GitHub slug
[ADR-0005] ✓ plugins[0] (aida-core): author.name \"aida-core\" is a valid GitHub slug
[ADR-0006] ✓ plugins[0] (aida-core): source.ref \"v1.4.6\" is a valid semver tag
[ADR-0007] ✓ plugins[0] (aida-core): category \"core\" is in the allow-list
[ADR-0009] - plugins[0] (aida-core): aida-core/aida-core-plugin is the AIDA foundation; exempt from ADR-0009

Validator summary: 5 passing, 0 failing, 1 skipped.
\`\`\`

## What's NOT in this PR

- **Contents validation** of \`aida-config.json\`. This rule checks existence only. A future ADR can layer schema validation of the config's contents.
- **Private plugin support.** Upstream is all-public; the default \`GITHUB_TOKEN\` works. Enterprise-profile marketplaces with private plugins use the App-authed pattern from ADR-0004.

## CI change

The \`Validate marketplace.json\` step now receives \`GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}\` so the rule can hit the Contents API.

## Local verification

- \`npm run typecheck\` ✓
- \`npm test\` ✓ (62/62, was 54/54)
- \`npm run validate\` ✓ — schema + 4 OK + 1 SKIP on current manifest