### PR TITLE
chore(ci): auto-label PRs based on changed paths (#51)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
+---
+# actions/labeler v5 config. Categories are applied based on the set of files
+# changed in a PR. Each category lists the globs that qualify.
+#
+# Match types:
+#   any-glob-to-any-file  — at least one file matches at least one glob
+#   all-globs-to-all-files — every changed file matches at least one glob (i.e. PR is
+#                            scoped entirely to these paths)
+#
+# `plugin-change`, `adr`, and `schema` are high-signal categories that apply when ANY
+# matching file is touched (even alongside other changes). `documentation`, `ci`, and
+# `tooling` are scope categories that apply only when the entire PR is scoped to those
+# paths — preventing a code-change PR that also touches docs from being mislabeled as
+# documentation-only.
+
+plugin-change:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".claude-plugin/marketplace.json"
+
+adr:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/adr/**"
+
+schema:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "schemas/**"
+
+documentation:
+  - changed-files:
+      - all-globs-to-all-files:
+          - "docs/**"
+          - "**/*.md"
+          - "README*"
+          - "CHANGELOG*"
+          - "AUTHORS"
+          - "MAINTAINERS*"
+          - "LICENSE*"
+          - "LICENSES/**"
+
+ci:
+  - changed-files:
+      - all-globs-to-all-files:
+          - ".github/workflows/**"
+          - ".github/dependabot.yml"
+          - ".github/labeler.yml"
+          - "renovate.json"
+
+tooling:
+  - changed-files:
+      - all-globs-to-all-files:
+          - "scripts/**"
+          - "Makefile"
+          - "package.json"
+          - "package-lock.json"
+          - "requirements-dev.txt"
+          - "tsconfig.json"
+          - ".yamllint.yml"
+          - ".markdownlint.yml"
+          - ".markdownlintignore"
+          - "REUSE.toml"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
+---
+name: Labeler
+
+# NOTE: `pull_request` (not `pull_request_target`) is deliberate. `pull_request_target`
+# runs in base-repo context with the write-scoped GITHUB_TOKEN exposed — safe today,
+# but a future contributor adding `actions/checkout` of the PR head would silently
+# expose the token to arbitrary fork code. Using `pull_request` removes that entire
+# class of mistake. The trade-off: fork PRs are labeled in the fork's context, which
+# is fine because this repo gates merges via CODEOWNERS. Switch only if a concrete
+# need to label fork PRs from the base context appears.
+on:
+  pull_request:
+
+# Least-privilege permissions. The labeler only needs to read paths and write labels.
+permissions:
+  contents: read
+  pull-requests: write
+
+# Cancel superseded runs when a PR is force-pushed or rapidly updated.
+concurrency:
+  group: labeler-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply labels
+    runs-on: ubuntu-latest
+    steps:
+      # actions/labeler v5.0.0 — SHA-pinned per the Phase 3 hardening direction (#20).
+      # Renovate maintains the pin; the version comment is for human readability.
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          # Sync only labels declared in `.github/labeler.yml`. Manually-applied
+          # labels not in that config (e.g. `good first issue`, `phase-*`) are
+          # untouched.
+          sync-labels: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- `.github/workflows/labeler.yml` and `.github/labeler.yml` —
+  auto-label PRs by changed paths using `actions/labeler@v5`
+  (SHA-pinned). Categories: `plugin-change` (marketplace.json),
+  `adr` (docs/adr/), `schema` (schemas/), `documentation` (all-md
+  PRs), `ci` (workflows-only), `tooling` (scripts/deps-only).
+  The high-signal categories (plugin-change, adr, schema) trigger
+  on any matching file; the scope categories (documentation, ci,
+  tooling) trigger only when the entire PR is scoped to those
+  paths. Workflow uses `pull_request` (not
+  `pull_request_target`) to keep the write-scoped token from
+  ever being exposed to fork-checkout code. Filed from #51.
+- New labels: `plugin-change`, `ci`, `tooling`, `adr`, `schema`,
+  and `skip-changelog` (the last was already referenced by the
+  changelog job but hadn't been created — caught during the
+  labeler implementation review).
 - ADR-0009: listed plugins must ship
   `.claude-plugin/aida-config.json` at the pinned `source.ref`.
   The AIDA foundation plugin (`aida-core/aida-core-plugin`) is


### PR DESCRIPTION
## Summary

Closes #51. Adds \`actions/labeler@v5\` (SHA-pinned) to auto-label PRs by changed paths. Six categories, see commit body and CHANGELOG.

## Design notes (per agent reviewer feedback)

- **\`pull_request\`, not \`pull_request_target\`** — keeps the write-scoped \`GITHUB_TOKEN\` from being exposed if anyone ever adds an \`actions/checkout\` of PR head. Fork PRs label in fork context; merges require CODEOWNERS approval.
- **Least-privilege permissions** at the workflow level (\`contents: read\`, \`pull-requests: write\`).
- **\`concurrency\`** block cancels superseded runs.
- **\`sync-labels: true\`** — only the labels declared in \`.github/labeler.yml\` are managed. Manual labels (e.g. phase-*, \`good first issue\`) are untouched.
- **High-signal vs scope split** — \`plugin-change\`, \`adr\`, \`schema\` fire on any matching file (high-signal). \`documentation\`, \`ci\`, \`tooling\` require the entire PR to be confined to those paths (avoids mislabeling code+docs PRs as docs-only).

## Repository state changes (already executed)

| Label | Color | Purpose |
| --- | --- | --- |
| \`plugin-change\` | green | Modifies marketplace.json |
| \`ci\` | blue | CI workflows / automation |
| \`tooling\` | purple | Build scripts, deps, lint configs |
| \`adr\` | dark blue | Architecture Decision Record |
| \`schema\` | yellow | JSON Schema changes |
| \`skip-changelog\` | gray | Caught during review — was referenced by CI but had never been created |

## What this PR should label itself as

\`ci\` (touches only \`.github/workflows/\` + \`.github/labeler.yml\` + CHANGELOG). Verify on the PR page after merge.

## Test plan

- [ ] CI green (yamllint, REUSE, no-AI-coauthor, changelog)
- [ ] Labeler runs against this PR on push (will need separate verification — labeler config doesn't exist on \`main\` until merge)
- [ ] Post-merge: open a one-line PR touching only \`docs/adr/0001-validator-language.md\` and verify both \`adr\` and \`documentation\` get applied
- [ ] Post-merge: open a one-line PR touching only \`scripts/validate-marketplace.ts\` and verify \`tooling\` gets applied, not \`documentation\`