### PR TITLE
chore(ci): lychee-based markdown link-check (#52)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
+---
+name: Link check
+
+# Validate markdown links via lychee. Runs:
+#   - on PRs that touch markdown (changed-files-scoped — don't burn API on
+#     code-only PRs)
+#   - weekly to catch link rot from upstream renames / deletions
+#   - on demand via workflow_dispatch
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "lychee.toml"
+      - ".github/workflows/link-check.yml"
+  schedule:
+    # Mondays 09:00 UTC. Renovate also runs Mondays (08:00); this is staggered
+    # so the two don't pile up on the same minute.
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+# Default to read-only. The scheduled job that opens issues for broken links
+# overrides at the job level (least-privilege per job).
+permissions:
+  contents: read
+
+concurrency:
+  group: link-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-scope:
+    name: PR scope (changed markdown only)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # tj-actions/changed-files is SHA-pinned. Handles first-push and
+      # force-push correctly (where a hand-rolled `git diff BASE_REF` would
+      # break).
+      - name: Get changed markdown files
+        id: changed
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: |
+            **/*.md
+
+      - name: Run lychee
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          # The action handles install + cache. Config and per-file scope come
+          # from lychee.toml and the changed-files output.
+          args: --config lychee.toml ${{ steps.changed.outputs.all_changed_files }}
+          # Hard-fail the PR on broken links. The 14-day age gate on Renovate
+          # already protects routine updates; PR-time link checks are the place
+          # to catch rot before merge.
+          fail: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  full-scan:
+    name: Full repo scan (scheduled / manual)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for the issue-creation step. Job-scoped, not top-level.
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: --config lychee.toml '**/*.md'
+          # Don't fail the cron run — surface broken links as a tracked issue
+          # instead. A red status check on the scheduled run vanishes into
+          # Actions history; an issue is something a human will see.
+          fail: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create issue on broken links
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
+        with:
+          title: "[link-check] Broken markdown links detected"
+          content-filepath: ./lychee/out.md
+          labels: |
+            bug
+            documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 - `.github/workflows/link-check.yml` — markdown link validation
   via lychee. Two jobs: a PR-scoped check (only the changed `.md`
   files, scoped via `tj-actions/changed-files`) that hard-fails
-  on broken links; and a weekly full-repo scan (Mondays 09:00 UTC)
-  + manual dispatch that runs against `**/*.md`. The scheduled
+  on broken links; and a weekly full-repo scan (Mondays 09:00 UTC,
+  with manual dispatch) that runs against `**/*.md`. The scheduled
   job soft-fails and opens a tracked issue (`bug` +
   `documentation` labels) via `peter-evans/create-issue-from-file`
   so broken links don't vanish into Actions history. All actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- `.github/workflows/link-check.yml` — markdown link validation
+  via lychee. Two jobs: a PR-scoped check (only the changed `.md`
+  files, scoped via `tj-actions/changed-files`) that hard-fails
+  on broken links; and a weekly full-repo scan (Mondays 09:00 UTC)
+  + manual dispatch that runs against `**/*.md`. The scheduled
+  job soft-fails and opens a tracked issue (`bug` +
+  `documentation` labels) via `peter-evans/create-issue-from-file`
+  so broken links don't vanish into Actions history. All actions
+  SHA-pinned per Phase 3 hardening direction (#20). Filed from #52.
+- `lychee.toml` at the repo root — lychee configuration. Networking
+  tuned for github.com (max 8 concurrent, 3 retries, 20s timeout).
+  Anchor validation enabled for local markdown cross-refs;
+  github.com fragments excluded because GitHub renders them
+  client-side and lychee can't reliably validate them. The
+  marketplace's `$schema` self-reference and GitHub API URL
+  templates in ADR text are also excluded. `429` is deliberately
+  NOT in the `accept` list — masking it would mask a real concurrency
+  tuning problem.
+- `make link-check` — local-runnable lychee invocation. Errors
+  out cleanly with an install hint if lychee isn't on PATH.
 - `.github/workflows/labeler.yml` and `.github/labeler.yml` —
   auto-label PRs by changed paths using `actions/labeler@v5`
   (SHA-pinned). Categories: `plugin-change` (marketplace.json),

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # AIDA Marketplace Makefile
 # Run `make help` for available targets
 
-.PHONY: help install lint lint-yaml lint-md lint-json lint-reuse typecheck check validate validate-frontmatter test
+.PHONY: help install lint lint-yaml lint-md lint-json lint-reuse typecheck check validate validate-frontmatter link-check test
 
 help: ## Show this help message
 	@echo "AIDA Marketplace - Available targets:"
@@ -44,6 +44,10 @@ validate: ## Run marketplace.json rule validation (per ADR-0001)
 
 validate-frontmatter: ## Validate YAML frontmatter on markdown files
 	python3 scripts/validate-frontmatter.py
+
+link-check: ## Validate markdown links via lychee (install: brew install lychee, or cargo install lychee)
+	@command -v lychee >/dev/null 2>&1 || { echo "ERROR: lychee not installed. brew install lychee  OR  cargo install lychee"; exit 1; }
+	lychee --config lychee.toml '**/*.md'
 
 test: ## Run unit tests
 	npm test

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
+# lychee config for markdown link validation. Used by
+# .github/workflows/link-check.yml on PRs and by `make link-check` locally.
+# Reference: https://github.com/lycheeverse/lychee/blob/master/docs/usage/configuration.md
+
+# --- Networking ---
+
+max_retries = 3
+retry_wait_time = 5  # seconds; lychee applies exponential backoff on top
+timeout = 20
+max_concurrency = 8
+
+# Cache between runs. lychee-action handles persistence in CI.
+cache = true
+max_cache_age = "1d"
+
+# --- What to accept ---
+
+# 200 and 206 (Partial Content) only. 429 (rate-limited) is NOT accepted here:
+# masking it would let a real rate-limit issue silently coexist with the
+# `max_retries`/`retry_wait_time` settings we just tuned, defeating the
+# adaptation. If 429s start showing up, the right fix is concurrency tuning,
+# not adding 429 to this list.
+accept = [200, 206]
+
+# Validate `#anchor` links within local markdown (md-to-md cross-refs).
+# Note: github.com URLs with fragments are excluded below because GitHub
+# renders anchors client-side and lychee can't reliably validate them.
+include_fragments = true
+
+# --- What to skip ---
+
+exclude_path = [
+  "node_modules",
+  "LICENSES",
+  ".git",
+  ".lycheecache",
+]
+
+# URL patterns to skip:
+exclude = [
+  # The marketplace's `$schema` field in .claude-plugin/marketplace.json points
+  # at the raw URL on main, which won't resolve on a PR that introduces or
+  # modifies the schema. Skip the self-reference; the validator + JSON tooling
+  # catch schema-shape problems directly.
+  '^https://raw\.githubusercontent\.com/aida-core/aida-marketplace/main/schemas/',
+
+  # GitHub renders fragments client-side; lychee fragment validation flakes on
+  # them. Skip github.com URLs that carry an anchor. The URL itself is still
+  # validated only via the bare URL (lychee strips the # before fetching).
+  '^https://github\.com/.*#',
+
+  # GitHub API URL templates referenced in ADR text and docstrings, e.g.
+  # https://api.github.com/users/{slug}. These contain a `{`/`}` placeholder
+  # which is never a real URL.
+  '^https://api\.github\.com/(users|orgs|repos)/\{',
+
+  # Placeholder example hosts used in code/doc examples.
+  '^https?://(www\.)?example\.(com|org)',
+]


### PR DESCRIPTION
## Summary

Closes #52. Two-job lychee workflow:

- **PR scope** — only the changed \`.md\` files (\`tj-actions/changed-files\` SHA-pinned). Hard-fail on broken links.
- **Full scan** — weekly cron + manual dispatch. Soft-fails, opens a tracked issue on broken links.

All third-party actions SHA-pinned per Phase 3 hardening direction (#20).

## Reviewer feedback baked in

| Concern | Resolution |
| --- | --- |
| Hand-rolled \`git diff BASE_REF\` is fragile on first/force pushes | Use \`tj-actions/changed-files\` SHA-pinned |
| 429 in \`accept\` masks real rate-limit issues | Removed; rely on retries + concurrency tuning |
| github.com fragment anchors flake (client-side render) | Exclude \`^https://github\.com/.*#\` |
| Schema URL self-reference (\`raw.githubusercontent.com/.../main/schemas/\`) won't resolve on schema-change PRs | Excluded |
| GitHub API URL templates in ADR text contain \`{placeholder}\` | Excluded |
| Cron failures vanish into Actions history | Soft-fail + issue creation via peter-evans/create-issue-from-file |
| Missing local-reproducibility (\`make link-check\` parity) | Added |
| Missing concurrency block | Added |
| Job-level vs top-level permissions | Top: \`contents: read\`. Job-level \`issues: write\` only on scheduled run |
| SPDX headers on new files | Workflow + lychee.toml both have \`#\` SPDX comments |

## Files

- \`.github/workflows/link-check.yml\` (new) — both jobs
- \`lychee.toml\` (new) — networking config, includes, excludes
- \`Makefile\` — added \`link-check\` target with install hint
- \`CHANGELOG.md\` — entries

## Test plan

- [ ] PR CI: yamllint, REUSE, no-AI-coauthor, changelog all pass
- [ ] PR CI: this PR touches \`.md\` (CHANGELOG) → \`pr-scope\` job runs against changed files; passes
- [ ] Post-merge: manually dispatch \`workflow_dispatch\` to verify the full-scan path
- [ ] Verify lychee.toml excludes resolve correctly (no false-positives from \`api.github.com/users/{slug}\` strings in ADRs)
- [ ] Local: \`make link-check\` errors cleanly when lychee isn't installed