### PR TITLE
chore(make): venv-based install + Makefile binary resolution (#48)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # Dependencies
 node_modules/
 
+# Python virtualenv (created by `make install` — never committed)
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+
 # Build output
 dist/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,27 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Changed
 
+- `Makefile` — `make install` now provisions a local Python
+  virtualenv at `.venv/` (skipping the PEP 668
+  "externally-managed-environment" trap on modern macOS / Python
+  3.12+). Targets resolve `$(PY)`, `$(YAMLLINT)`, and `$(REUSE)`
+  via `$(if $(wildcard $(VENV)/bin/X),...)` with recursive
+  expansion (`=`, not `:=`) so the wildcard re-evaluates each
+  recipe call — `make install lint` in a single invocation
+  picks up the freshly-installed venv binaries for the lint
+  step. Make 3.81-compatible (no `export PATH`).
+  `validate-frontmatter` now invokes `$(PY)` instead of bare
+  `python3`. CI is unchanged: it pip-installs to the Actions
+  Python and the wildcards fall through to PATH binaries.
+- `.gitignore` — adds `.venv/`, `__pycache__/`, `*.pyc`,
+  `*.pyo` so the venv and Python build artifacts are never
+  committed. (REUSE respects gitignore, so `make lint-reuse`
+  continues to pass after `make install`.)
+- New `make clean-venv` target removes `.venv/` for a clean
+  rebuild.
+- Resolves #48. Follow-ups: pin exact versions / add
+  `--require-hashes` to `requirements-dev.txt`; migrate CI to
+  use `make install` for a single source of truth.
 - CI: the `Validate marketplace.json` step now receives
   `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` so ADR-0009 can hit
   the Contents API for each listed plugin.

--- a/Makefile
+++ b/Makefile
@@ -4,33 +4,61 @@
 # AIDA Marketplace Makefile
 # Run `make help` for available targets
 
-.PHONY: help install lint lint-yaml lint-md lint-json lint-reuse typecheck check validate validate-frontmatter link-check test
+.PHONY: help install clean-venv lint lint-yaml lint-md lint-json lint-reuse typecheck check validate validate-frontmatter link-check test
+
+# --- Python venv resolution -------------------------------------------------
+#
+# `make install` provisions a local Python venv in .venv/ so contributors on
+# modern macOS / Python 3.12+ don't hit PEP 668 "externally-managed-environment"
+# errors. The variables below use RECURSIVE expansion (`=`, not `:=`) so the
+# $(wildcard) check is re-evaluated each time the variable is referenced — that
+# way `make install lint` in a single invocation correctly picks up the freshly
+# created venv binaries for the lint step.
+#
+# CI doesn't run `make install`; it pip-installs to the GitHub Actions Python
+# directly. When .venv/ is absent, the wildcards fall through to system
+# binaries on PATH. Same Makefile, both worlds.
+#
+# Make 3.81-compatible (no `export PATH`, no `.ONESHELL`).
+
+VENV := .venv
+PY = $(if $(wildcard $(VENV)/bin/python),$(VENV)/bin/python,python3)
+YAMLLINT = $(if $(wildcard $(VENV)/bin/yamllint),$(VENV)/bin/yamllint,yamllint)
+REUSE = $(if $(wildcard $(VENV)/bin/reuse),$(VENV)/bin/reuse,reuse)
+
+# --- Targets ----------------------------------------------------------------
 
 help: ## Show this help message
 	@echo "AIDA Marketplace - Available targets:"
 	@echo ""
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 
 # Dependencies
-install: ## Install Node and Python dev dependencies
+install: ## Install Node and Python dev dependencies (creates .venv/ if missing)
 	npm ci
-	pip install -r requirements-dev.txt
+	@command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 is not installed or not on PATH." >&2; exit 1; }
+	@test -d $(VENV) || python3 -m venv $(VENV)
+	$(VENV)/bin/pip install --upgrade pip
+	$(VENV)/bin/pip install -r requirements-dev.txt
+
+clean-venv: ## Remove the local Python virtualenv
+	rm -rf $(VENV)
 
 # Linting
 lint: lint-yaml lint-md lint-json lint-reuse ## Run all linters (YAML, Markdown, JSON, REUSE)
 
 lint-yaml: ## Run yamllint on YAML files
-	yamllint .github/workflows/ .yamllint.yml .markdownlint.yml
+	$(YAMLLINT) .github/workflows/ .yamllint.yml .markdownlint.yml
 
 lint-md: ## Run markdownlint-cli2 on Markdown files
 	markdownlint-cli2 '**/*.md'
 
 lint-json: ## Validate marketplace.json
-	python3 -m json.tool .claude-plugin/marketplace.json > /dev/null
+	$(PY) -m json.tool .claude-plugin/marketplace.json > /dev/null
 
 lint-reuse: ## Verify REUSE / SPDX compliance (every file has copyright + license info)
-	reuse lint
+	$(REUSE) lint
 
 # Typecheck + plugin validation (mirrors the CI typecheck job)
 typecheck: ## Run TypeScript typecheck
@@ -43,10 +71,10 @@ validate: ## Run marketplace.json rule validation (per ADR-0001)
 	npm run validate
 
 validate-frontmatter: ## Validate YAML frontmatter on markdown files
-	python3 scripts/validate-frontmatter.py
+	$(PY) scripts/validate-frontmatter.py
 
 link-check: ## Validate markdown links via lychee (install: brew install lychee, or cargo install lychee)
-	@command -v lychee >/dev/null 2>&1 || { echo "ERROR: lychee not installed. brew install lychee  OR  cargo install lychee"; exit 1; }
+	@command -v lychee >/dev/null 2>&1 || { echo "ERROR: lychee not installed. brew install lychee  OR  cargo install lychee" >&2; exit 1; }
 	lychee --config lychee.toml '**/*.md'
 
 test: ## Run unit tests


### PR DESCRIPTION
## Summary

Closes #48. Provisions a local Python virtualenv at \`.venv/\` via \`make install\`, sidestepping the PEP 668 \"externally-managed-environment\" trap on modern macOS / Python 3.12+.

## How it works

\`\`\`makefile
VENV := .venv
PY = \$(if \$(wildcard \$(VENV)/bin/python),\$(VENV)/bin/python,python3)
YAMLLINT = \$(if \$(wildcard \$(VENV)/bin/yamllint),\$(VENV)/bin/yamllint,yamllint)
REUSE = \$(if \$(wildcard \$(VENV)/bin/reuse),\$(VENV)/bin/reuse,reuse)
\`\`\`

- **Local dev**: \`make install\` provisions \`.venv/\`; subsequent targets resolve to venv binaries automatically.
- **CI**: pip installs to GHA Python before make runs; no venv exists; wildcards fall through to PATH binaries. Same Makefile.
- **Same invocation pattern**: \`make install lint\` works because the wildcard uses RECURSIVE expansion (\`=\`, not \`:=\`), re-evaluating each recipe call.

## Reviewer feedback baked in

| Catch | Resolution |
| --- | --- |
| \`:=\` would parse-time-fix wildcards before venv exists | Use \`=\` (recursive) |
| Targets calling bare \`python3\`/\`yamllint\`/\`reuse\` would skip venv | Explicit \`\$(PY)/\$(YAMLLINT)/\$(REUSE)\` in every target |
| \`validate-frontmatter\` invoked via bare \`python3\` | Now uses \`\$(PY)\` |
| Missing python3 preflight | Added \`command -v python3\` check |
| \`.venv/\` not gitignored | Added (plus \`__pycache__/\`, \`*.pyc\`, \`*.pyo\`) |
| REUSE would scan \`.venv/\` and fail | REUSE respects gitignore — verified locally that \`make lint-reuse\` still passes after \`make install\` |
| No clean target | Added \`make clean-venv\` |

## Local verification

\`\`\`
\$ rm -rf .venv && make install
[installs into .venv/]
\$ make -n lint-yaml lint-reuse validate-frontmatter
.venv/bin/yamllint ...
.venv/bin/reuse lint
.venv/bin/python scripts/validate-frontmatter.py
\$ make validate-frontmatter
Frontmatter validation: 1 passing, 0 failing, 14 skipped.
\`\`\`

## Follow-ups (deferred)

- Pin exact versions / add \`--require-hashes\` to \`requirements-dev.txt\` for supply-chain hardening. Will file as a separate issue.
- Migrate CI lint job to use \`make install\` for one source of truth on dep install.

## Test plan

- [ ] CI green (unchanged CI flow, wildcards fall through to PATH)
- [ ] Local on macOS Python 3.12: \`rm -rf .venv && make install\` succeeds (no PEP 668 error)
- [ ] \`make -n lint-yaml\` shows \`.venv/bin/yamllint\` when venv exists, bare \`yamllint\` after \`make clean-venv\`
- [ ] \`make help\` renders all targets correctly