### PR TITLE
feat: ADR-0010 branch protection baseline + runbook (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- ADR-0010: branch protection baseline. Profile-conditional
+  (Simple vs Enterprise per ADR-0002) with full security control
+  set on both — `required_signatures` (signed commits),
+  `required_conversation_resolution`, explicit
+  `allow_force_pushes: false` / `allow_deletions: false`,
+  `required_status_checks.strict: true`, and tag protection for
+  `v*` (per ADR-0006's pinning semantics). Simple profile
+  (this repo) keeps `require_code_owner_reviews: false` and
+  `enforce_admins: false` because CODEOWNERS has a single entry
+  today; named trigger to re-enable code-owner-review once
+  CODEOWNERS has two or more entries. Enterprise sets
+  `enforce_admins: true` (no admin bypass) and linear history.
+  Filed from #49.
+- `docs/runbooks/branch-protection.md` — operational runbook with
+  literal `gh api` snippets per profile. Includes prerequisites
+  (signed commits set up), PUT-is-REPLACE semantics warning,
+  status-check job-name mapping, repo-level control notes
+  (Dependabot/secret scanning), and common scenarios (sole
+  maintainer admin bypass, Renovate auto-merge, re-enabling
+  code-owner-review when team grows).
+- `MAINTAINERS.md` — Owner role section now cross-references
+  ADR-0010 and the runbook.
 - `.github/workflows/link-check.yml` — markdown link validation
   via lychee. Two jobs: a PR-scoped check (only the changed `.md`
   files, scoped via `tj-actions/changed-files`) that hard-fails

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,6 +18,11 @@ the people who must review.
 - **GitHub access:** admin.
 - **What they can do:** bypass branch protection, modify CI/CD, force-push
   (when temporarily allowed), configure repo settings, cut releases.
+- **Branch protection contract:** see [ADR-0010](docs/adr/0010-branch-protection-baseline.md)
+  for the baseline and [docs/runbooks/branch-protection.md](docs/runbooks/branch-protection.md)
+  for the `gh api` commands to apply / re-apply the policy. Owner admin
+  bypass is the documented escape hatch under the Simple profile while
+  CODEOWNERS has a single entry — recorded in the GitHub audit log.
 
 ### Committer
 

--- a/docs/adr/0010-branch-protection-baseline.md
+++ b/docs/adr/0010-branch-protection-baseline.md
@@ -1,0 +1,188 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0010: Branch protection baseline
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Filed from:** [#49](https://github.com/aida-core/aida-marketplace/issues/49)
+
+## Context
+
+Marketplaces are high-blast-radius repositories. A bad merge to `main`
+propagates to every operator who runs `/plugin install` against the
+marketplace — there is no staging layer between this repo's `main` and a
+plugin landing on someone's machine. The CI gates we've built (typecheck,
+linters, validator, JSON schema check, frontmatter check, link check) are
+the *machine* enforcement. Branch protection is the *policy* enforcement
+that says: "no PR merges unless those gates have actually run and passed."
+
+Until now this repo's branch protection has been configured ad-hoc.
+[#49](https://github.com/aida-core/aida-marketplace/issues/49) asks us to
+document the baseline so it's:
+
+- visible to contributors (the contract is explicit),
+- reproducible (a scaffolded downstream marketplace can apply it from a
+  runbook), and
+- auditable (drift is observable against a written reference).
+
+[ADR-0002](./0002-marketplace-profiles.md) established Simple vs Enterprise
+operator profiles. Branch protection is exactly the kind of policy that
+should differ between them: a public, solo-maintained marketplace has very
+different "blast radius vs friction" tradeoffs than a private internal
+marketplace with a dedicated review team.
+
+## Considered options
+
+1. **No documented baseline — operator's choice.**
+   - Pros: zero work; full flexibility.
+   - Cons: every new marketplace re-invents the wheel; drift across
+     downstream marketplaces; no auditability.
+
+2. **One global baseline applied uniformly.**
+   - Pros: uniform contract everywhere.
+   - Cons: over-engineered for solo Simple operators (every routine merge
+     needs admin override); under-engineered for Enterprise (no signed
+     commits, no strict checks, no audit-logged admin bypass).
+
+3. **Profile-conditional baselines mirroring ADR-0002.**
+   - Pros: matches the operator-profile model the rest of our governance
+     uses; downstream marketplaces inherit by declaring their profile.
+   - Cons: two baselines to maintain.
+
+## Decision
+
+Adopt **option 3**. Two baselines, both applying the full GitHub branch
+protection security control set, with profile-specific differences in
+review depth and admin bypass.
+
+### Common controls (both profiles)
+
+These apply to `main` regardless of profile:
+
+| Control | Setting | Why |
+| --- | --- | --- |
+| `dismiss_stale_reviews_on_push` | `true` | A new push invalidates prior approval. |
+| `required_signatures` | `true` | Pairs with the no-AI-coauthor CI gate ([ADR-0005](./0005-author-and-owner-identity.md) identity context). Forces verifiable commit authorship. |
+| `required_conversation_resolution` | `true` | All PR review threads must be resolved before merge. |
+| `allow_force_pushes` | `false` | History is append-only on `main`. |
+| `allow_deletions` | `false` | `main` cannot be deleted. |
+| `required_status_checks.strict` | `true` | Branches must be up-to-date with `main` before merge. |
+| Tag protection on `v*` | enabled | Release tags are the marketplace's pinning surface (per [ADR-0006](./0006-semver-tag-refs.md)). Rewriting/deleting them breaks consumers. |
+
+Required status check contexts (workflow job names that GitHub gates on):
+
+- `TypeScript` (typecheck + tests + validator + version check)
+- `Lint` (yaml + md + json + REUSE + frontmatter)
+- `No AI Co-Authors`
+- `Changelog`
+- `PR scope (changed markdown only)` (link-check on PRs)
+
+Deliberately **NOT** required: `Apply labels` (the labeler workflow). A
+labeler failure shouldn't block merges — labels are signal, not safety.
+
+### Simple profile (this repo's baseline)
+
+| Control | Setting | Why |
+| --- | --- | --- |
+| `required_approving_review_count` | `1` | Minimum threshold for external contributions. |
+| `require_code_owner_reviews` | `false` | See "Sole-code-owner tension" below. |
+| `require_last_push_approval` | `false` | A maintainer's approval persists across their own fixup commits (combined with `dismiss_stale` for substantive changes). |
+| `enforce_admins` (UI: "Include administrators") | `false` | Admin bypass available for solo-maintainer edge cases. Bypass is recorded in the audit log. |
+
+### Enterprise profile
+
+| Control | Setting | Why |
+| --- | --- | --- |
+| `required_approving_review_count` | `2` | Two-eyes principle for any merge. |
+| `require_code_owner_reviews` | `true` | CODEOWNERS roster expected to have ≥2 entries; assigns review authority by path. |
+| `require_last_push_approval` | `true` | Stricter than Simple: any subsequent push requires re-approval. |
+| `enforce_admins` | `true` | No admin bypass. Even admins go through the review gate. |
+| Linear history | `true` | Recommended; keeps git history clean for audit. |
+
+### Sole-code-owner tension (Simple profile)
+
+This repo currently has one CODEOWNERS entry (`@oakensoul`). Setting
+`require_code_owner_reviews: true` on a single-code-owner repo creates a
+self-approval deadlock — GitHub disallows PR authors from approving their
+own PRs, so every PR by the owner requires admin bypass. Renovate's
+auto-merge for trusted-source minor/patch updates ([ADR-0002](./0002-marketplace-profiles.md))
+breaks for the same reason.
+
+Disabling `require_code_owner_reviews` on Simple resolves both problems
+without meaningfully reducing safety:
+
+1. The 1-required-approval requirement still blocks external contributors
+   from self-merging.
+2. The required status checks (validator, no-AI-coauthor, linters) are
+   non-bypassable from a reviewer perspective — they fail or they pass.
+3. `enforce_admins: false` provides a documented escape hatch logged in
+   the GitHub audit trail.
+
+**Named trigger to re-enable:** when this repo's `.github/CODEOWNERS`
+has two or more entries (or any entry beyond the global `@oakensoul`
+wildcard), a follow-up PR MUST flip `require_code_owner_reviews` to
+`true`. This is the only deferred decision in ADR-0010.
+
+### Rulesets vs classic branch protection
+
+GitHub now offers two mechanisms for branch policy enforcement:
+
+- **Classic branch protection** (what this ADR documents) — single
+  per-branch policy applied via `/repos/{owner}/{repo}/branches/{branch}/protection`.
+- **Repository Rulesets** — newer, layerable, with finer control. Multiple
+  rulesets can stack.
+
+For v1 of the reference marketplace, classic branch protection is
+sufficient and is the better-documented path for scaffolded downstreams.
+Migrating to Rulesets is a future ADR if the layering becomes useful.
+
+## Consequences
+
+**Gained:**
+
+- Contract is visible to contributors and auditable against the runbook.
+- Downstream marketplaces inherit a copyable baseline by declaring their
+  profile in their README.
+- The required-status-check list is now an explicit dependency of the
+  workflow names — renaming a job is a breaking change that the runbook
+  surfaces.
+- Renovate's auto-merge (per [ADR-0002](./0002-marketplace-profiles.md)
+  Simple profile) works without per-PR admin override.
+
+**Accepted costs:**
+
+- Two baselines to maintain. Each must be kept in sync with the actual
+  workflow job names in `.github/workflows/`.
+- Branch protection is *not* mechanically validated by our validator
+  ([ADR-0001](./0001-validator-language.md)) — it's GitHub-enforced. Drift
+  detection is manual (re-run the runbook periodically).
+- `required_signatures: true` requires contributors to sign commits with
+  GPG or SSH. This is a real friction increase from today. Until contributors
+  have signing configured, applying this control will block their PRs.
+  Apply only after operators have set up signing per GitHub's docs.
+
+## Enforcement
+
+This ADR is **documentation-driven**. GitHub enforces branch protection
+directly; there is no validator rule because there is no manifest to
+validate.
+
+- Runbook: [`docs/runbooks/branch-protection.md`](../runbooks/branch-protection.md)
+  — literal `gh api` commands per profile. Operators apply the baseline by
+  running the commands.
+- The runbook notes that the GitHub branch-protection PUT endpoint is
+  REPLACE semantics (not merge) — the full JSON payload is required each
+  time. Partial payloads silently zero out unrelated settings.
+- Drift detection: there is no automated drift check today. Filed as a
+  follow-up under [#49](https://github.com/aida-core/aida-marketplace/issues/49)
+  — a future scheduled workflow could compare live protection against the
+  baseline JSON and open an issue on drift.
+- CODEOWNERS validation: a malformed `.github/CODEOWNERS` silently
+  disables code-owner-review enforcement. Verify with `gh api
+  repos/{owner}/{repo}/codeowners/errors` periodically. Filed as a
+  follow-up.
+
+When the workflow set changes (new required check, renamed job), update
+the required-status-checks list in both the runbook and the Simple/Enterprise
+baselines in this ADR's tables. The PR doing the rename MUST update both.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,3 +40,4 @@ See [`0000-adr-template.md`](./0000-adr-template.md). Copy it, rename, fill in.
 | 0007 | [Closed allow-list for plugin categories](./0007-category-allow-list.md) | Accepted | [#45](https://github.com/aida-core/aida-marketplace/issues/45) |
 | 0008 | [JSON Schema as the canonical structural definition](./0008-json-schemas.md) | Accepted | [#50](https://github.com/aida-core/aida-marketplace/issues/50) |
 | 0009 | [Listed plugins must ship `.claude-plugin/aida-config.json`](./0009-aida-config-required.md) | Accepted | [#44](https://github.com/aida-core/aida-marketplace/issues/44) |
+| 0010 | [Branch protection baseline](./0010-branch-protection-baseline.md) | Accepted | [#49](https://github.com/aida-core/aida-marketplace/issues/49) |

--- a/docs/runbooks/branch-protection.md
+++ b/docs/runbooks/branch-protection.md
@@ -1,0 +1,219 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Runbook: apply the branch-protection baseline
+
+Operational reference for applying the baseline defined in
+[ADR-0010](../adr/0010-branch-protection-baseline.md). Two profiles —
+**Simple** (this repo) and **Enterprise** (downstream private marketplaces) —
+each with full security control set.
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated as a user with **admin** access to
+  the target repo.
+- Contributors have set up signed commits per
+  [GitHub's docs](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+  **before** applying — `required_signatures: true` will block any unsigned
+  commit. If contributors aren't ready, comment out that field in the
+  payload until they are.
+
+## Important: PUT semantics are REPLACE, not MERGE
+
+The GitHub branch-protection PUT endpoint
+(`/repos/{owner}/{repo}/branches/{branch}/protection`) **replaces** the
+entire policy with the supplied payload. A partial payload silently zeroes
+out unrelated settings.
+
+> Always send the full JSON every time. Don't try to patch fields
+> individually.
+
+The snippets below are complete payloads. Apply by piping into
+`gh api -X PUT`.
+
+## Status-check naming
+
+The strings in `required_status_checks.contexts` must match the workflow
+**job names** exactly. From the current workflows:
+
+| Job name | Source file |
+| --- | --- |
+| `TypeScript` | `.github/workflows/ci.yml` (typecheck job) |
+| `Lint` | `.github/workflows/ci.yml` (lint job) |
+| `Changelog` | `.github/workflows/ci.yml` (changelog job) |
+| `No AI Co-Authors` | `.github/workflows/no-ai-coauthor.yml` |
+| `PR scope (changed markdown only)` | `.github/workflows/link-check.yml` (pr-scope job) |
+
+Deliberately **not** required: `Apply labels` (the labeler workflow) —
+labeling is signal, not safety.
+
+If a workflow job is renamed, update this runbook and the baseline JSON
+in the same PR.
+
+## Simple profile (this repo)
+
+Per ADR-0010: 1 approval required, no code-owner-review (sole-maintainer
+context), admin bypass allowed (logged in the audit trail), full control
+set otherwise.
+
+```bash
+gh api -X PUT repos/aida-core/aida-marketplace/branches/main/protection \
+  -H "Accept: application/vnd.github+json" \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "TypeScript",
+      "Lint",
+      "No AI Co-Authors",
+      "Changelog",
+      "PR scope (changed markdown only)"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "require_code_owner_reviews": false,
+    "dismiss_stale_reviews": true,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "required_signatures": true,
+  "required_conversation_resolution": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "lock_branch": false
+}
+JSON
+```
+
+Tag protection for `v*` (separate API):
+
+```bash
+gh api -X POST repos/aida-core/aida-marketplace/tags/protection \
+  -H "Accept: application/vnd.github+json" \
+  -f pattern='v*'
+```
+
+## Enterprise profile (downstream private marketplaces)
+
+Per ADR-0010: 2 approvals + code-owner-review (assumes ≥2 entries in
+CODEOWNERS), last-push approval, no admin bypass, linear history.
+
+Replace `<OWNER>/<REPO>` with your marketplace's owner/repo.
+
+```bash
+gh api -X PUT repos/<OWNER>/<REPO>/branches/main/protection \
+  -H "Accept: application/vnd.github+json" \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "TypeScript",
+      "Lint",
+      "No AI Co-Authors",
+      "Changelog",
+      "PR scope (changed markdown only)"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 2,
+    "require_code_owner_reviews": true,
+    "dismiss_stale_reviews": true,
+    "require_last_push_approval": true
+  },
+  "restrictions": null,
+  "required_signatures": true,
+  "required_conversation_resolution": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "lock_branch": false,
+  "required_linear_history": true
+}
+JSON
+```
+
+Tag protection for `v*`:
+
+```bash
+gh api -X POST repos/<OWNER>/<REPO>/tags/protection \
+  -H "Accept: application/vnd.github+json" \
+  -f pattern='v*'
+```
+
+## Verifying current settings
+
+After applying, read back the live state:
+
+```bash
+gh api repos/aida-core/aida-marketplace/branches/main/protection \
+  -H "Accept: application/vnd.github+json"
+```
+
+The returned JSON should match the payload above field-for-field (modulo
+GitHub-added fields like `url`).
+
+For tag protection:
+
+```bash
+gh api repos/aida-core/aida-marketplace/tags/protection \
+  -H "Accept: application/vnd.github+json"
+```
+
+## Repository-level controls (out of scope for branch protection)
+
+These complement branch protection but live at the repo level (not on the
+branch endpoint). Confirm via the GitHub UI under **Settings → Security**:
+
+- Dependabot alerts: **enabled** (we use Renovate for updates; alerts
+  still surface CVEs)
+- Secret scanning: **enabled**
+- Push protection for secrets: **enabled**
+
+These cannot be cleanly set via the branch-protection runbook; treat them
+as a separate one-time setup.
+
+## Rulesets vs classic (forward-looking)
+
+This runbook targets GitHub's classic branch-protection API. GitHub
+Rulesets are a newer, layerable alternative. ADR-0010 names classic as
+the current canonical path; migration to Rulesets is a future ADR.
+
+## Common operational scenarios
+
+### "I'm a solo maintainer and my PR is stuck on 0/1 approvals"
+
+Use the admin bypass:
+
+```bash
+gh pr merge <NUMBER> --admin --squash --delete-branch
+```
+
+`enforce_admins: false` on Simple makes this legal. The bypass is
+recorded in the GitHub audit log. This is the documented escape hatch —
+not a hack.
+
+### "Renovate auto-merge isn't landing on a Simple-profile repo"
+
+Likely cause: `require_code_owner_reviews: true` or
+`required_approving_review_count > 0`. Renovate's auto-merge bypasses
+code-owner-review but still respects approval-count. If you have 1 approval
+required and no humans approve, Renovate's PR sits indefinitely. The
+Simple baseline above (1 approval, no code-owner-review) only resolves
+this for Renovate PRs if you can configure Renovate to self-approve (out
+of scope for this runbook).
+
+### "CI gates pass but I want to merge anyway, bypassing branch protection"
+
+Use the admin bypass above. If you find yourself doing this routinely,
+the policy is misaligned with your workflow — open an ADR-amendment PR.
+
+### "I want to re-enable `require_code_owner_reviews` because we now
+have 2 code owners"
+
+Update `.github/CODEOWNERS` first. Then flip the field in the Simple
+payload above and re-run. Document the change in CHANGELOG and reference
+this runbook.

--- a/docs/runbooks/branch-protection.md
+++ b/docs/runbooks/branch-protection.md
@@ -211,8 +211,7 @@ of scope for this runbook).
 Use the admin bypass above. If you find yourself doing this routinely,
 the policy is misaligned with your workflow — open an ADR-amendment PR.
 
-### "I want to re-enable `require_code_owner_reviews` because we now
-have 2 code owners"
+### "I want to re-enable `require_code_owner_reviews` (we have 2+ code owners now)"
 
 Update `.github/CODEOWNERS` first. Then flip the field in the Simple
 payload above and re-run. Document the change in CHANGELOG and reference


### PR DESCRIPTION
## Summary

Closes #49. Documents the branch protection baseline as a profile-conditional ADR with a literal \`gh api\` runbook.

**This PR is documentation-only.** The actual branch protection on this repo is applied separately by running the Simple-profile snippet from the runbook (requires admin + signed commits set up).

## Both profiles share the full security set

- \`required_signatures\` (signed commits)
- \`required_conversation_resolution\`
- explicit \`allow_force_pushes: false\`, \`allow_deletions: false\`
- \`required_status_checks.strict: true\`
- tag protection for \`v*\` (per ADR-0006 pinning semantics)

## Profile-specific differences

| Setting | Simple | Enterprise |
| --- | --- | --- |
| Required approvals | 1 | 2 |
| Require code-owner-review | **false** | true |
| Require last-push approval | false | true |
| Admin bypass | allowed (logged) | disallowed |
| Linear history | (allowed) | required |

The Simple-profile choice to disable code-owner-review is the load-bearing decision. Reasoning: this repo has a single CODEOWNERS entry; requiring code-owner-review creates self-approval deadlock and breaks Renovate auto-merge. Named trigger to re-enable: \"once CODEOWNERS has 2+ entries.\"

## Reviewer feedback baked in

- **Excluded \"Apply labels\" from required checks** (would block PRs on labeler outages; labeling is signal, not safety)
- **PUT-is-REPLACE semantics** called out explicitly in the runbook
- **Status-check name mapping** documented (workflow job name → required-context string)
- **Sole-code-owner tension** resolved with explicit named trigger
- **Renovate auto-merge interaction** documented in runbook's scenarios section
- **Rulesets vs classic** noted as forward-looking
- **Repo-level controls** (Dependabot, secret scanning, push protection) flagged as sibling controls outside branch-protection scope
- **Tag protection** added (separate gh api endpoint)
- **Cross-refs** to ADR-0002 (profiles), ADR-0005 (signed commits + identity), ADR-0006 (tag pinning)

## Files

| File | Purpose |
| --- | --- |
| \`docs/adr/0010-branch-protection-baseline.md\` | The decision |
| \`docs/runbooks/branch-protection.md\` | Operational \`gh api\` snippets per profile |
| \`docs/adr/README.md\` | Index updated |
| \`MAINTAINERS.md\` | Owner section cross-refs runbook |
| \`CHANGELOG.md\` | Entry |

## Test plan

- [ ] CI green (lint, REUSE, no-AI-coauthor, changelog, link-check on the new .md files)
- [ ] Manual: post-merge, apply Simple baseline via the runbook to this repo
- [ ] Manual: \`gh api repos/aida-core/aida-marketplace/branches/main/protection\` returns JSON matching the documented payload

## Out of scope (filed as follow-up)

- Scheduled drift-detection workflow
- CODEOWNERS validation check
- Rulesets migration