### PR TITLE
chore: workflow hardening + secret patterns + Dependabot alerts (#20)

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -9,9 +9,11 @@ on:
     - cron: "0 8 * * 1" # Monday 8am UTC
   workflow_dispatch:
 
+# Workflow-level default is read-only. The single job below escalates to
+# write because it opens an automation PR — keeping the escalation
+# job-scoped is defense in depth against future jobs inheriting write.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: plugin-updates
@@ -20,10 +22,13 @@ concurrency:
 jobs:
   check-updates:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,19 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege default for the workflow. Every job here only reads the
+# repo; nothing writes back. Per #20 Phase 3 hardening.
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     name: TypeScript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
 
@@ -43,14 +48,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
@@ -81,7 +86,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -36,7 +36,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # tj-actions/changed-files is SHA-pinned. Handles first-push and
       # force-push correctly (where a hand-rolled `git diff BASE_REF` would
@@ -70,7 +70,7 @@ jobs:
       # Required for the issue-creation step. Job-scoped, not top-level.
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run lychee
         id: lychee

--- a/.github/workflows/no-ai-coauthor.yml
+++ b/.github/workflows/no-ai-coauthor.yml
@@ -8,12 +8,16 @@ on:
   pull_request:
     branches: [main]
 
+# Read-only across the workflow. The scan just reads commit messages.
+permissions:
+  contents: read
+
 jobs:
   no-ai-coauthors:
     name: No AI Co-Authors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,42 @@ dist/
 .env
 .env.*
 
+# Secrets / credentials (defense-in-depth — never commit these by accident)
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.jks
+*.keystore
+id_rsa
+id_rsa.*
+id_ed25519
+id_ed25519.*
+id_ecdsa
+id_ecdsa.*
+id_dsa
+id_dsa.*
+credentials
+credentials.*
+secrets.yaml
+secrets.yml
+*.gpg
+*.asc
+.netrc
+.npmrc
+.pypirc
+
+# Cloud / infra credentials
+kubeconfig
+*.kubeconfig
+.kube/config
+.aws/credentials
+.aws/config
+*.tfstate
+*.tfstate.backup
+.terraform/
+
 # IDE
 .vscode/
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,42 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Changed
 
+- All CI workflows now declare top-level
+  `permissions: contents: read` as a least-privilege baseline.
+  Jobs that need broader scope (`check-updates.yml` opens PRs,
+  `link-check.yml` schedules issue creation, `labeler.yml`
+  writes labels) escalate at the job level instead of the
+  workflow level — defense in depth against future jobs
+  inheriting write scope they don't need. Filed from #20.
+- All third-party GitHub Actions across every workflow are now
+  SHA-pinned with a trailing `# vX.Y.Z` comment for human
+  readability. Previously `ci.yml`, `no-ai-coauthor.yml`, and
+  `check-updates.yml` referenced `actions/checkout@v4`,
+  `actions/setup-node@v4`, `actions/setup-python@v5` by tag;
+  now they reference the specific commit SHAs that those tags
+  resolved to. Matches the pattern already used in
+  `labeler.yml` and `link-check.yml`. Filed from #20.
+- `.gitignore` — secret patterns block expanded substantially.
+  In addition to the existing `.env`/`.env.*`, now ignores:
+  `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.crt`, `*.jks`,
+  `*.keystore`, `id_rsa*`, `id_ed25519*`, `id_ecdsa*`, `id_dsa*`,
+  `credentials*`, `secrets.y*ml`, `*.gpg`, `*.asc`, `.netrc`,
+  `.npmrc`, `.pypirc`, `kubeconfig`, `*.kubeconfig`, `.kube/config`,
+  `.aws/credentials`, `.aws/config`, `*.tfstate*`, `.terraform/`.
+  Defense-in-depth against accidental key/credential commits.
+  Filed from #20.
+- `docs/runbooks/branch-protection.md` — repository-level
+  controls section now includes literal `gh api` commands for
+  enabling Dependabot vulnerability **alerts** (notifications,
+  no PRs — complement Renovate) and explicitly documents that
+  Dependabot **security updates** are deliberately DISABLED
+  because Renovate already owns the CVE-PR lane (per
+  ADR-0002). A separate block covers secret scanning + push
+  protection setup. Filed from #20.
+- Dependabot vulnerability alerts ENABLED on this repo (one-time
+  `gh api PUT vulnerability-alerts`). Notifications only;
+  Renovate continues to own update PRs. Dependabot security
+  updates remain disabled to avoid duplicate CVE PRs.
 - `Makefile` — `make install` now provisions a local Python
   virtualenv at `.venv/` (skipping the PEP 668
   "externally-managed-environment" trap on modern macOS / Python

--- a/docs/runbooks/branch-protection.md
+++ b/docs/runbooks/branch-protection.md
@@ -166,15 +166,77 @@ gh api repos/aida-core/aida-marketplace/tags/protection \
 ## Repository-level controls (out of scope for branch protection)
 
 These complement branch protection but live at the repo level (not on the
-branch endpoint). Confirm via the GitHub UI under **Settings → Security**:
+branch endpoint). They're not part of the branch-protection JSON payload
+but ARE part of the recommended baseline. Apply via the snippets below or
+under **Settings → Security** in the GitHub UI.
 
-- Dependabot alerts: **enabled** (we use Renovate for updates; alerts
-  still surface CVEs)
-- Secret scanning: **enabled**
-- Push protection for secrets: **enabled**
+### Dependabot vulnerability alerts (alerts only — NOT update PRs)
 
-These cannot be cleanly set via the branch-protection runbook; treat them
-as a separate one-time setup.
+Renovate owns ALL update PRs per [ADR-0002](../adr/0002-marketplace-profiles.md),
+including CVE patches (auto-merged at patch+minor for trusted sources).
+Dependabot **alerts** are a *different* feature: GitHub-hosted CVE
+notifications backed by the GHSA database that surface vulnerabilities
+without opening PRs. Enabling alerts alongside Renovate is
+non-conflicting because alerts don't open PRs.
+
+```bash
+# Enable Dependabot vulnerability alerts (notifications only)
+gh api -X PUT repos/aida-core/aida-marketplace/vulnerability-alerts
+```
+
+### Dependabot security updates — DELIBERATELY OFF
+
+Dependabot's "security updates" feature opens PRs for known-vulnerable
+versions. Renovate already does this for us (per ADR-0002, with the
+`vulnerabilityAlerts` block in the org-level config). Enabling Dependabot
+security updates alongside Renovate would create **duplicate PRs** for
+every CVE. We disable it deliberately:
+
+```bash
+# Disable Dependabot security update PRs (Renovate owns this lane)
+gh api -X DELETE repos/aida-core/aida-marketplace/automated-security-fixes
+```
+
+Verify:
+
+```bash
+gh api repos/aida-core/aida-marketplace \
+  --jq '.security_and_analysis.dependabot_security_updates.status'
+# Expected: "disabled"
+```
+
+**Enterprise profile note:** if a downstream marketplace doesn't use
+Renovate for some reason (Mend hosting policy, etc.), Dependabot security
+updates ARE the right substitute. Enable in that case via:
+
+```bash
+gh api -X PUT repos/<OWNER>/<REPO>/automated-security-fixes
+```
+
+### Secret scanning + push protection
+
+If/when the repo is upgraded to a plan that supports it (currently
+included on public repos and on GitHub Enterprise Cloud):
+
+```bash
+gh api -X PATCH repos/aida-core/aida-marketplace \
+  -H "Accept: application/vnd.github+json" \
+  --input - <<'JSON'
+{
+  "security_and_analysis": {
+    "secret_scanning": { "status": "enabled" },
+    "secret_scanning_push_protection": { "status": "enabled" }
+  }
+}
+JSON
+```
+
+Verify all three via:
+
+```bash
+gh api repos/aida-core/aida-marketplace \
+  --jq '.security_and_analysis'
+```
 
 ## Rulesets vs classic (forward-looking)
 


### PR DESCRIPTION
## Summary

Partial close of #20 (Phase 3 hardening). Closes 5 of 16 checklist sub-items; remaining work tracked as follow-up issues #76-#81.

## What's in this PR

| Area | Change |
| --- | --- |
| Workflow permissions | All workflows declare top-level \`permissions: contents: read\`. \`check-updates.yml\` escalates at job level (defense in depth). |
| Action SHA pins | All third-party Actions across all 5 workflows SHA-pinned with \`# vX.Y.Z\` comment. Was \`@v4\`/\`@v5\` tags. |
| \`.gitignore\` secrets | Expanded from \`.env\` only to 30+ patterns covering keys, credentials, GPG, kubeconfig, AWS, Terraform state. |
| Dependabot alerts | Enabled (one-time \`gh api PUT\`). Notifications only; Renovate keeps owning update PRs per ADR-0002. |
| Dependabot security updates | **Deliberately disabled** to avoid duplicate CVE PRs with Renovate (good catch from review). |
| Runbook update | \`docs/runbooks/branch-protection.md\` now has literal \`gh api\` commands for the repo-level controls section. |

## Follow-up issues filed (already created)

| # | Title |
| --- | --- |
| #76 | npm audit + policy ADR |
| #77 | release workflow + SBOM |
| #78 | pre-commit hooks evaluation |
| #79 | marketplace-specific issue templates |
| #80 | optional local CONTRIBUTING addendum |
| #81 | CODEOWNERS validation in CI |

## Reviewer feedback baked in

| Catch | Resolution |
| --- | --- |
| \`link-check.yml\` \`actions/checkout\` not SHA-pinned | Pinned in this PR |
| \`check-updates.yml\` top-level write perms is broad | Moved to job-level escalation |
| Dependabot security updates would duplicate Renovate CVE PRs | Deliberately disabled, documented |
| Need literal gh api commands in runbook | Added |
| Missing secret patterns (kubeconfig, .aws/, terraform, npmrc) | Added |
| Trailing version comments on SHA pins | Added (\`# vX.Y.Z\` format) |
| File follow-up issues before PR closes | Done (#76-#81) |

## Status of remaining #20 sub-items

- **DONE** (already in repo): SPDX headers, CHANGELOG, CODEOWNERS — pre-merge
- **ORG-COVERED** (intentional Simple-profile choice): SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, generic issue/PR templates
- **Not applicable**: Dependabot updates (Renovate owns; would conflict)
- **In this PR**: workflow perms, SHA pins, gitignore secrets, Dependabot alerts
- **Follow-ups**: #76-#81

## Test plan

- [ ] All CI gates pass on this PR (proves \`contents: read\` doesn't break any step)
- [ ] Verify Dependabot alerts enabled: \`gh api repos/aida-core/aida-marketplace/vulnerability-alerts\` → 204
- [ ] Verify Dependabot security updates disabled: \`gh api repos/aida-core/aida-marketplace --jq '.security_and_analysis.dependabot_security_updates.status'\` → \"disabled\"
- [ ] Confirm SHA pins resolve to expected versions (gh api repos/actions/checkout/git/refs/tags/v4.3.1 etc.)