### PR TITLE
docs: CLAUDE.md + knowledge/ progressive-disclosure pattern (#47)

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -16,3 +16,11 @@ MD033:
 # Allow duplicate headings in different sections
 MD024:
   siblings_only: true
+
+# Files in this repo combine YAML frontmatter (with a `title:` field for
+# AIDA's frontmatter validator) and a body H1 (for human readers + GitHub
+# rendering). MD025's default treats both as top-level titles. Disable
+# frontmatter-title detection so the body H1 is the only H1 markdownlint
+# counts.
+MD025:
+  front_matter_title: ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,34 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- `CLAUDE.md` at the repo root — Claude Code project memory.
+  Identity, repo layout, hard rules summarized from accepted
+  ADRs 0001–0010, command reference, and a `knowledge/` map
+  that names each file so Claude can `Read` it on demand.
+  Carries YAML frontmatter (`type: documentation`) for AIDA
+  tooling compliance, but the frontmatter is metadata for
+  AIDA validators — not what Claude Code keys on for loading.
+  Filed from #47.
+- `knowledge/` directory with progressive-disclosure reference
+  material for contributors and Claude Code:
+  - `index.md` — catalog + audience-mode guidance (human /
+    Claude / new-knowledge-author)
+  - `workflows.md` — concrete contributor recipes (add a
+    plugin, bump a version, rebuild the manifest, add a
+    validator rule, amend the category allow-list, add an
+    ADR, apply branch protection, investigate version drift,
+    respond to link-check failures)
+  - `tooling.md` — inventory of every tool starting with the
+    `.claude-plugin/` layout: schemas, validators, CI
+    workflows, Renovate setup, REUSE tooling, Makefile
+  - `troubleshooting.md` — common CI failures and fixes
+    (REUSE, frontmatter, lychee, validator rules, signed
+    commits, no-AI-coauthor, Renovate didn't run)
+- Pattern is intended to be copied by downstream marketplaces
+  scaffolded from this repo. The companion ADR index at
+  `docs/adr/README.md` and operational runbooks in
+  `docs/runbooks/` are linked from the new files; not
+  duplicated.
 - ADR-0010: branch protection baseline. Profile-conditional
   (Simple vs Enterprise per ADR-0002) with full security control
   set on both — `required_signatures` (signed commits),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+---
+type: documentation
+title: AIDA Marketplace — project context for Claude Code
+description: Always-loaded project memory for Claude Code working on aida-marketplace. Hard rules, repo layout, command reference, and a map into knowledge/ for deeper context loaded on demand.
+audience: contributors
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# AIDA Marketplace — Claude Code project memory
+
+This repo is the **canonical reference marketplace for AIDA**. `aida-core-plugin`
+will eventually scaffold downstream marketplaces from this one. Quality bar is
+high: patterns here are designed to be copied verbatim.
+
+This file is loaded into every conversation. Keep it terse. Deeper material
+lives in `knowledge/` — load those files via `Read` when the question calls for
+them (see Knowledge map below).
+
+## Repo layout
+
+```text
+.claude-plugin/marketplace.json   — the manifest Claude Code reads
+schemas/marketplace.schema.json   — structural schema (referenced by manifest's $schema)
+scripts/                          — TypeScript validator, frontmatter validator, update tool
+docs/adr/                         — Architecture Decision Records (0001–0010)
+docs/runbooks/                    — operational runbooks (branch-protection, etc.)
+knowledge/                        — progressively-read reference material (this directory)
+.github/workflows/                — CI: typecheck, lint, validator, frontmatter, link-check, labeler
+renovate.json                     — Renovate per-repo overrides (extends aida-core/.github)
+```
+
+## Hard rules (from accepted ADRs — see `docs/adr/README.md`)
+
+- **Entry kind + suffix match.** Every `plugins[]` entry has `kind: "plugin"`
+  or `kind: "guidebook"`, and `source.repo` ends with that suffix. (ADR-0003)
+- **Identity is a GitHub slug.** `owner.name` and `plugins[].author.name` are
+  GitHub slugs only. No `email`, no `owner.url`. (ADR-0005)
+- **Refs are semver tags.** `source.ref` matches `v?\d+\.\d+\.\d+$`. No
+  branches, no SHAs, no pre-release/build-metadata tags. (ADR-0006)
+- **Categories are a closed set.** `category` is one of `core`, `workflow`,
+  `infrastructure`, `language`, `integration`, `domain`, `productivity`,
+  `security`, `observability`. (ADR-0007)
+- **Listed plugins ship `.claude-plugin/aida-config.json`** at the pinned
+  `source.ref`. The foundation (`aida-core/aida-core-plugin`) is exempt.
+  (ADR-0009)
+- **JSON Schema is the structural source of truth.** `schemas/marketplace.schema.json`
+  defines the manifest shape; validator runs ajv first, semantic rules second.
+  (ADR-0008)
+- **Rule = ADR + check in same PR.** Adding a new constraint means writing an
+  ADR, updating the schema (if structural), and adding a validator rule —
+  in one PR. (#42)
+- **No AI co-author trailers.** The `no-ai-coauthor.yml` CI gate blocks PRs
+  whose commits contain AI attribution. There's no skip label.
+- **SPDX header on every hand-authored file.** REUSE lint is a blocking gate.
+- **Signed commits required on `main`.** Per ADR-0010 branch protection.
+
+## Commands
+
+| Command | What |
+| --- | --- |
+| `make install` | Create `.venv/`, install npm + Python dev deps |
+| `make lint` | yamllint, markdownlint, json, REUSE |
+| `make validate` | Run the marketplace.json validator (schema + ADR rules) |
+| `make validate-frontmatter` | Validate YAML frontmatter on `.md` files |
+| `make test` | Unit tests via `node:test` |
+| `make typecheck` | `tsc --noEmit` |
+| `make link-check` | lychee against all markdown |
+| `make check` | Plugin version check (calls `gh api`) |
+| `npm run update` | Apply pending version bumps to `marketplace.json` |
+
+## Knowledge map
+
+When a question goes beyond the hard rules above, `Read` one of these:
+
+- `knowledge/index.md` — catalog of this directory + audience-mode guidance
+- `knowledge/workflows.md` — step-by-step recipes (add a plugin, amend an ADR,
+  add a validator rule, rebuild the manifest, bump a category)
+- `knowledge/tooling.md` — inventory of every tool, what it does, where it
+  lives (validator, schema, Renovate, lychee, labeler, CI workflows, AI
+  co-author gate)
+- `knowledge/troubleshooting.md` — common contributor failures (REUSE lint,
+  frontmatter, link-check, signed commits, validator rules)
+
+Knowledge files carry YAML frontmatter for AIDA's frontmatter validator
+(per ADR-0008). The frontmatter is metadata for AIDA tooling, **not** a
+signal Claude Code uses to choose which file to load — the file path being
+mentioned here is what makes Claude aware that the file is worth reading.
+
+For ADR depth, read `docs/adr/README.md` for the index, then the specific
+ADR. Don't paraphrase ADRs from memory — they are short, read the source.
+
+## Related
+
+- `README.md` — installation and consumer-facing docs
+- `MAINTAINERS.md` — role model (Owner / Committer / Collaborator)
+- `docs/runbooks/branch-protection.md` — `gh api` commands for ADR-0010
+- `CHANGELOG.md` — Keep a Changelog format; updated on every PR
+- `.github/CODEOWNERS` — required-reviewer rules

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -1,0 +1,51 @@
+---
+type: reference
+title: Knowledge index — aida-marketplace contributor docs
+description: Catalog of progressively-loaded reference material for contributors and Claude Code. Routes to workflows, tooling, troubleshooting; not loaded unconditionally.
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Knowledge index
+
+Progressive-disclosure reference material for `aida-marketplace`. Read these
+on demand; `CLAUDE.md` at the repo root has the always-loaded hard rules and
+command reference.
+
+The companion ADR index lives at [`docs/adr/README.md`](../docs/adr/README.md).
+Operational runbooks live in [`docs/runbooks/`](../docs/runbooks/). Don't
+duplicate that content here — link to it.
+
+## Files in this directory
+
+| File | Purpose | Read when… |
+| --- | --- | --- |
+| [`index.md`](./index.md) | This catalog | You want to know what else exists |
+| [`workflows.md`](./workflows.md) | Step-by-step contributor recipes | You're trying to *do* something (add a plugin, amend an ADR, rebuild the manifest, etc.) |
+| [`tooling.md`](./tooling.md) | Inventory of every tool, schema, and config | You want to know *what's wired up* (validator, Renovate, lychee, labeler, AI-coauthor gate, etc.) |
+| [`troubleshooting.md`](./troubleshooting.md) | Common contributor failure modes | A check is red and you don't know why (REUSE, frontmatter, lychee, signed commits, validator rules) |
+
+## Audience modes
+
+- **Human contributor** — start with the README, glance at `workflows.md` for
+  the recipe that matches your task, drop into `tooling.md` or specific ADRs
+  as needed.
+- **Claude Code working on a PR** — `CLAUDE.md` is already loaded. Read the
+  specific knowledge file that matches the question; don't bulk-read this
+  directory. ADRs are short — read the source rather than paraphrase.
+- **Author of a new knowledge file** — match the frontmatter shape used by
+  existing files. Don't restate ADRs or runbooks; link them. The line
+  between "this file" and "an ADR" is: ADRs record *decisions*; knowledge
+  files record *how to navigate and apply* those decisions.
+
+## What's NOT in this directory
+
+- **ADRs themselves** — they live in [`docs/adr/`](../docs/adr/). Read
+  [`docs/adr/README.md`](../docs/adr/README.md) for the index. There is no
+  separate `governance.md` here — adding one would just duplicate the ADR
+  index and drift on the first amendment.
+- **Branch-protection commands** — in [`docs/runbooks/branch-protection.md`](../docs/runbooks/branch-protection.md).
+- **Org-wide contributor process** — in `aida-core/.github` (CONTRIBUTING.md
+  at the org level applies as a fallback).
+- **Consumer-facing install instructions** — in the root [`README.md`](../README.md).

--- a/knowledge/tooling.md
+++ b/knowledge/tooling.md
@@ -1,0 +1,130 @@
+---
+type: reference
+title: Tooling inventory — validators, CI, Renovate, schemas
+description: What's wired up in aida-marketplace and where each tool lives. Reference for contributors who need to know which check enforces what before they touch a file.
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Tooling inventory
+
+## `.claude-plugin/` — the manifest layer
+
+| File | What |
+| --- | --- |
+| `.claude-plugin/marketplace.json` | The manifest Claude Code reads. Has `$schema` pointing at the canonical schema. |
+
+The manifest is the single source of truth for what plugins/guidebooks the
+marketplace lists. Every validator and CI check ultimately targets this
+file.
+
+## `schemas/` — structural definitions
+
+| File | What |
+| --- | --- |
+| `schemas/marketplace.schema.json` | JSON Schema draft-07 for `marketplace.json`. Mirrors value-level constraints from ADRs 0003, 0005, 0006, 0007. Cross-field rules (kind ↔ suffix matching) live in the validator, not here. (ADR-0008) |
+
+The frontmatter schema for markdown files is **referenced not vendored**.
+It lives at `aida-core/aida-core-plugin/.frontmatter-schema.json` and is
+fetched by `validate-frontmatter.py` at runtime (or overridden via
+`$AIDA_FRONTMATTER_SCHEMA`).
+
+## `scripts/` — TypeScript validator + helpers
+
+| File | What |
+| --- | --- |
+| `scripts/validate-marketplace.ts` | The validator. Loads the schema, runs ajv structural validation, then runs 5 ADR-traced semantic rules. Exits 1 if any rule emits a FAIL. |
+| `scripts/marketplace-types.ts` | Shared TypeScript types for the manifest. Imported by both `update-marketplace.ts` and `validate-marketplace.ts`. |
+| `scripts/validate-marketplace.test.ts` | 62 unit tests using `node:test` (built-in; no extra deps). Run via `make test`. |
+| `scripts/update-marketplace.ts` | The version-bump and README-render tool. Called by `npm run check` (read-only) and `npm run update` (writes). |
+| `scripts/validate-frontmatter.py` | Python frontmatter validator. Fetches schema from upstream URL by default; skips files without frontmatter (gradual adoption). |
+| `scripts/add_spdx_headers.py` | One-shot SPDX header insertion tool. Idempotent. |
+
+The validator's `Rule` interface is the extension point. Add a new rule
+by appending to `RULES` and updating `marketplace.schema.json`/tests — see
+`knowledge/workflows.md` § "Add a new validator rule."
+
+## `.github/workflows/` — CI
+
+| Workflow | Triggers | Purpose |
+| --- | --- | --- |
+| `ci.yml` | push/PR to main | TypeScript (typecheck + tests + validator + `npm run check`), Lint (yaml/md/json/REUSE/frontmatter), Changelog gate |
+| `no-ai-coauthor.yml` | PR to main | Scans PR commit trailers for AI co-author attribution and rejects |
+| `check-updates.yml` | Mon 08:00 UTC + dispatch | Legacy auto-PR for plugin version bumps. Renovate is the primary path now |
+| `labeler.yml` | PR to main | `actions/labeler` applies category labels by changed paths |
+| `link-check.yml` | PR (when md changes) + Mon 09:00 UTC + dispatch | lychee link validation; PR job fails on broken links, cron job opens an issue |
+
+All workflows have top-level `permissions: contents: read` as the
+least-privilege baseline. Jobs that need broader scope (PR creation, issue
+creation, label writes) escalate at job level.
+
+All third-party Actions are SHA-pinned with a trailing `# vX.Y.Z` comment;
+Renovate maintains the pins.
+
+## Renovate (org-extended)
+
+Per ADR-0002, this repo uses the Simple profile. Configuration:
+
+- **Org-level defaults** live in `aida-core/.github/default.json`:
+  custom regex manager for marketplace `source.ref` values, labeling rules
+  (`trusted-source` / `external-source` / `major-version`), supply-chain
+  gates (`minimumReleaseAge: "14 days"`, `minimumConfidence: "high"`),
+  CVE auto-merge for patch+minor via `vulnerabilityAlerts`.
+- **Per-repo overrides** in `renovate.json`: extend the org config; enable
+  auto-merge for `aida-core/*` minor/patch; set `minimumReleaseAge: "0 days"`
+  for `aida-core/*` (we own those plugins).
+
+## Dependabot
+
+- **Vulnerability alerts:** enabled. Surfaces CVEs from the GHSA database.
+- **Security updates:** deliberately disabled — Renovate already handles
+  CVE-patch auto-merge, and enabling Dependabot security updates would
+  create duplicate PRs.
+
+See [`docs/runbooks/branch-protection.md`](../docs/runbooks/branch-protection.md)
+for the `gh api` commands.
+
+## REUSE / SPDX
+
+- `REUSE.toml` covers JSON files (which can't carry inline SPDX) and a few
+  named config files (AUTHORS, .gitignore, .markdownlintignore, .gitkeep).
+- `LICENSES/MPL-2.0.txt` carries the canonical license text.
+- `make lint-reuse` is a blocking CI gate via `reuse lint`.
+- New hand-authored files MUST carry an SPDX header
+  (`SPDX-FileCopyrightText` + `SPDX-License-Identifier`).
+- `scripts/add_spdx_headers.py` exists for one-shot rollouts.
+
+## Linting + formatting
+
+| Tool | Where | Notes |
+| --- | --- | --- |
+| `yamllint` | `.yamllint.yml` | Workflow YAML + dotfiles |
+| `markdownlint-cli2` | `.markdownlint.yml` | 300-char line limit, blank lines around lists/headings |
+| `tsc --noEmit` | `tsconfig.json` | TypeScript strict mode |
+| `reuse` | `REUSE.toml` | SPDX/REUSE compliance |
+| `lychee` | `lychee.toml` | Markdown link validation |
+
+## Branch protection (GitHub-enforced)
+
+See [`docs/runbooks/branch-protection.md`](../docs/runbooks/branch-protection.md)
+and [ADR-0010](../docs/adr/0010-branch-protection-baseline.md).
+
+Required status checks for Simple-profile (this repo): `TypeScript`,
+`Lint`, `No AI Co-Authors`, `Changelog`, `PR scope (changed markdown only)`.
+
+## Makefile
+
+The Makefile is the single entry point for every local command. `$(PY)`,
+`$(YAMLLINT)`, `$(REUSE)` resolve to venv binaries (`.venv/bin/...`) if
+`make install` has been run, system binaries otherwise. Recursive
+expansion (`=`, not `:=`) so `make install lint` in one invocation works
+correctly. Make 3.81-compatible (no `export PATH`).
+
+## What's NOT here
+
+- **Pre-commit hooks** — deferred to follow-up [#78](https://github.com/aida-core/aida-marketplace/issues/78).
+- **`npm audit` in CI** — deferred to [#76](https://github.com/aida-core/aida-marketplace/issues/76); policy ADR pending.
+- **Release workflow + SBOM** — deferred to [#77](https://github.com/aida-core/aida-marketplace/issues/77).
+- **CODEOWNERS validation** — deferred to [#81](https://github.com/aida-core/aida-marketplace/issues/81).
+- **Marketplace-specific issue templates** — deferred to [#79](https://github.com/aida-core/aida-marketplace/issues/79).

--- a/knowledge/troubleshooting.md
+++ b/knowledge/troubleshooting.md
@@ -1,0 +1,186 @@
+---
+type: reference
+title: Troubleshooting — common CI failures and contributor traps
+description: Concrete fixes for the failure modes contributors hit most often. Use as a runbook when CI is red and the error isn't obvious.
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Troubleshooting
+
+Common failures and what to do about each. If a failure isn't listed
+here, file an issue noting which CI gate emitted it — that's how this
+file grows.
+
+## REUSE / SPDX lint failed
+
+**Symptom:** `make lint-reuse` (or CI `Lint` job) fails with
+`MISSING COPYRIGHT AND LICENSING INFORMATION`.
+
+**Why:** Every hand-authored source file must carry SPDX headers.
+JSON files (which can't have inline comments) are covered by
+`REUSE.toml` aggregate annotations. Other files need inline headers.
+
+**Fix:**
+
+- **Markdown:** add at the top, after frontmatter if any:
+
+  ```markdown
+  <!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+  <!-- SPDX-License-Identifier: MPL-2.0 -->
+  ```
+
+- **TS / JS / Python:** `// SPDX-...` or `# SPDX-...` near the top of
+  the file (after any shebang).
+- **YAML / TOML:** `# SPDX-...` near the top.
+- **Bulk fix:** `scripts/add_spdx_headers.py` runs idempotently.
+
+If the missing file is something REUSE can't carry inline (lockfiles,
+fixtures), add an annotation to `REUSE.toml`.
+
+## Frontmatter validation failed
+
+**Symptom:** `make validate-frontmatter` or the `Lint` CI job emits a
+`FAIL <path>: <field>: <message>` line.
+
+**Why:** A markdown file's YAML frontmatter doesn't match the AIDA
+frontmatter schema (fetched from upstream `aida-core/aida-core-plugin`).
+
+**Fix:**
+
+- Required fields by `type`:
+  - `documentation`, `guide`, `reference` — `title` (description recommended)
+  - `adr` — `title`, `status` (proposed/accepted/deprecated/superseded), `date`
+  - `skill`, `agent` — `name`, `description`, `version`, `tags`
+- Reference the upstream schema if the message is unclear: [.frontmatter-schema.json](https://github.com/aida-core/aida-core-plugin/blob/main/.frontmatter-schema.json).
+- Offline / sibling-clone dev: set `AIDA_FRONTMATTER_SCHEMA=/path/to/.frontmatter-schema.json`.
+- For files that legitimately have no frontmatter, that's OK — the
+  validator skips them. Don't add empty frontmatter to silence it.
+
+## `link-check` PR job failed
+
+**Symptom:** CI `PR scope (changed markdown only)` job fails with a list
+of broken links.
+
+**Why:** lychee found a URL or anchor it couldn't resolve.
+
+**Fix:**
+
+- If the link is genuinely dead: update or remove it.
+- If the failure is a github.com anchor (`#L42`, `#some-header`):
+  lychee can't reliably validate client-side rendered anchors.
+  Check `lychee.toml` — the github.com fragment exclude
+  (`^https://github\.com/.*#`) should already cover it. If a new
+  pattern is needed, add it there.
+- If it's the marketplace's own `$schema` URL on a schema-change PR:
+  the self-reference doesn't resolve until merge. Verify the exclude
+  pattern `^https://raw.githubusercontent.com/aida-core/aida-marketplace/main/schemas/`
+  is still in place.
+- If it's a transient network error: lychee retries 3× before
+  failing. Push an empty commit to re-run; if recurring, tune
+  `lychee.toml`'s `max_retries`/`max_concurrency`.
+
+## Validator rule failed (`[ADR-NNNN] ✗ …`)
+
+**Symptom:** `make validate` or the CI `TypeScript` job emits
+`[ADR-NNNN] ✗ <context>: <message>`.
+
+**Why:** The marketplace manifest violates an enforced rule. The ADR
+number in the message names the rationale.
+
+**Fix:**
+
+- Read the ADR (`docs/adr/NNNN-*.md`). The Decision section explains
+  what's expected; the Enforcement section explains exactly what the
+  validator checks.
+- Common rules to check first:
+  - **ADR-0003** kind / suffix mismatch: rename the repo or change
+    the `kind` field
+  - **ADR-0005** GitHub slug: `email` is forbidden, `owner.url` is
+    forbidden, `name` must match `^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$`
+  - **ADR-0006** ref not semver: must match `^v?\d+\.\d+\.\d+$` — no
+    pre-release, no build metadata
+  - **ADR-0007** category not in allow-list: pick from the nine, or
+    follow `workflows.md` to amend the list
+  - **ADR-0009** missing `aida-config.json`: upstream repo needs the
+    file at the pinned ref (the foundation `aida-core/aida-core-plugin`
+    is exempt)
+
+## Schema validation failed (`[schema] ✗ …`)
+
+**Symptom:** The validator emits a `[schema] ✗ /path/to/field: ...`
+line BEFORE any ADR rules run.
+
+**Why:** The manifest fails structural validation against
+`schemas/marketplace.schema.json` (ajv). Semantic rules can't run on
+broken structure.
+
+**Fix:**
+
+- The error path (`/plugins/0/category`, etc.) points at the failing
+  field. Cross-reference the schema to see what shape is expected.
+- Most common: missing required field (`name`, `kind`, `source`,
+  `author`), wrong enum value, type mismatch, additional unexpected
+  property.
+
+## Signed-commit check failed
+
+**Symptom:** Branch protection rejects the PR with "requires signed
+commits."
+
+**Why:** ADR-0010 enforces signed commits on `main`. Your commits
+aren't GPG/SSH-signed.
+
+**Fix:**
+
+- Configure commit signing per GitHub's
+  [docs](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- For SSH signing: `git config --global gpg.format ssh` +
+  `git config --global user.signingkey ~/.ssh/your_key.pub` +
+  `git config --global commit.gpgsign true`.
+- Re-sign existing commits: `git rebase --exec 'git commit --amend
+  --no-edit -S' origin/main`.
+
+## `make lint-md` errors locally but I don't have `markdownlint-cli2`
+
+**Symptom:** `make lint-md` says
+`markdownlint-cli2: No such file or directory`.
+
+**Why:** Not installed. CI installs it as part of the `Lint` job.
+
+**Fix:** `npm install -g markdownlint-cli2` (one-time global install),
+or rely on CI.
+
+## `no-ai-coauthor` check failed
+
+**Symptom:** The `No AI Co-Authors` workflow rejects the PR.
+
+**Why:** A commit in the PR has a `Co-Authored-By:` trailer pointing
+at an AI tool (Claude, Copilot, ChatGPT, Cursor, etc.) or an
+`@anthropic.com`/`@openai.com` noreply address.
+
+**Fix:**
+
+- `git log --format='%B' origin/main..HEAD` to find the offending
+  commit.
+- Rebase and rewrite: `git rebase -i origin/main`, edit the bad commit
+  to drop the trailer.
+- Force-push the cleaned branch.
+- There's no `skip-` label — the policy is firm.
+
+## Renovate didn't open a PR I expected
+
+**Symptom:** A plugin shipped a new release; no Renovate PR appeared.
+
+**Why:** Most likely the `minimumReleaseAge` gate (14 days globally,
+0 days for `aida-core/*`). Or the release isn't a github-release (only
+git tags don't trigger the regex manager).
+
+**Fix:**
+
+- Check the Renovate Dependency Dashboard issue for the repo.
+- Confirm the upstream release was a github-release (not just a tag).
+- For non-`aida-core/*` plugins, wait the 14-day age gate.
+- For verification: `gh workflow run check-updates.yml` (the legacy
+  fallback) will also open a PR if drift exists.

--- a/knowledge/workflows.md
+++ b/knowledge/workflows.md
@@ -1,0 +1,158 @@
+---
+type: guide
+title: Contributor workflows — common recipes
+description: Step-by-step recipes for the contributor tasks that recur most often on aida-marketplace. Each recipe names the files touched, the CI gates that will check the work, and links to deeper material.
+audience: contributors
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Contributor workflows
+
+Each recipe below is task-shaped, not process-shaped. PR mechanics
+(branches, commit format, no-AI-coauthor) live in the org-level
+`CONTRIBUTING.md` and `MAINTAINERS.md` — not duplicated here.
+
+## Add a new plugin to the marketplace
+
+1. Pick the `kind` — `plugin` (capability) or `guidebook` (curated set of
+   agents with progressive domain knowledge) per [ADR-0003](../docs/adr/0003-marketplace-entry-kinds.md).
+2. Verify the upstream repo's name ends with the matching suffix
+   (`-plugin` or `-guidebook`). If it doesn't, the upstream needs renaming
+   first — the validator will fail the listing.
+3. Verify the upstream repo ships `.claude-plugin/aida-config.json` at the
+   ref you intend to pin. (ADR-0009; foundation `aida-core/aida-core-plugin`
+   is the only exemption.)
+4. Pick a `category` from the closed allow-list in
+   [ADR-0007](../docs/adr/0007-category-allow-list.md). If none fits, that's
+   the "amend the allow-list" recipe below — not a free-form pick.
+5. Append a new entry to `plugins[]` in `.claude-plugin/marketplace.json`:
+
+   ```json
+   {
+     "name": "short-id",
+     "kind": "plugin",
+     "source": { "source": "github", "repo": "owner/short-id-plugin", "ref": "v1.0.0" },
+     "description": "Short, factual sentence.",
+     "version": "1.0.0",
+     "category": "one-of-the-nine",
+     "homepage": "https://github.com/owner/short-id-plugin",
+     "author": { "name": "owner" },
+     "tags": ["concise", "kebab-case"]
+   }
+   ```
+
+6. Run `make validate`. The validator will tell you exactly which ADR
+   each failing rule traces to.
+7. Update `CHANGELOG.md` under `[Unreleased] > Added`.
+8. PR. CI runs `TypeScript` (typecheck + tests + validator), `Lint`,
+   `Changelog`, `No AI Co-Authors`, `link-check pr-scope`, and `Apply
+   labels`.
+
+## Bump a plugin's pinned version (manual path)
+
+Most version bumps happen automatically via Renovate (see `tooling.md`).
+When you need to bump manually:
+
+1. From a clean clone: `npm run update`. This calls
+   `scripts/update-marketplace.ts` to fetch each plugin's latest release
+   tag and rewrite `marketplace.json` deterministically.
+2. Review the diff. The script also rewrites the plugin table in
+   `README.md` (via marker comments).
+3. `make validate` to confirm the rewrites still pass.
+4. CHANGELOG entry under `Changed`.
+
+## Rebuild `marketplace.json` after a manual edit
+
+The output format is `JSON.stringify(marketplace, null, 2) + "\n"`. If you
+ever hand-edit and accidentally indent differently, run
+`scripts/update-marketplace.ts --update` to re-emit deterministically.
+
+If you change a field structure (e.g., adding `kind`), update
+`schemas/marketplace.schema.json` in the same PR and re-run
+`make validate` to confirm.
+
+## Add a new validator rule
+
+Per the [#42](https://github.com/aida-core/aida-marketplace/issues/42)
+governance pattern: rule = ADR + check + tests in **one PR**.
+
+1. Write an ADR under `docs/adr/NNNN-rule-slug.md` following
+   `0000-adr-template.md`. Status: Accepted by the time the PR merges.
+2. If the rule is structural (a missing/required field, an enum, a
+   pattern): update `schemas/marketplace.schema.json` to express it.
+3. Add the rule to `scripts/validate-marketplace.ts`:
+   - Define `adrNNNN: Rule = { id, title, check(marketplace) { ... } }`
+   - Append to the `RULES` array.
+   - Use the `[ADR-NNNN]` prefix in every failure message so contributors
+     can find the rationale from CI output.
+4. Add unit tests in `scripts/validate-marketplace.test.ts`. Cover OK,
+   FAIL, and SKIP cases. The existing rules average ~7 tests each — match
+   that depth.
+5. Update `docs/adr/README.md` to list the new ADR.
+6. CHANGELOG entry under `Added`.
+7. `make typecheck && make test && make validate` locally before pushing.
+
+## Add a new category to the allow-list
+
+ADR-0007 explicitly governs this. The recipe:
+
+1. Confirm there's a concrete planned listing that doesn't fit any of the
+   nine existing categories. ADR-0007 says: don't add anticipatory
+   categories.
+2. Amend `docs/adr/0007-category-allow-list.md`. Add the row to the
+   Decision table (category, meaning, example). Status stays `Accepted`
+   — this is an in-place amendment, not a new ADR, unless the change is
+   structural.
+3. Update `ALLOWED_CATEGORIES` in `scripts/validate-marketplace.ts`.
+4. Update the enum in `schemas/marketplace.schema.json` (`properties.category.enum`).
+5. Add the planned listing to `marketplace.json` in the same PR (so the
+   new category isn't sitting there unused).
+6. CHANGELOG entry.
+
+## Add a new ADR (no validator rule)
+
+For decisions that don't manifest as a manifest rule (governance,
+process, profile choices, etc.):
+
+1. Copy `docs/adr/0000-adr-template.md` to `docs/adr/NNNN-slug.md`.
+2. Fill Status / Date / Filed from / Context / Considered options /
+   Decision / Consequences / Enforcement.
+3. Update `docs/adr/README.md`.
+4. CHANGELOG entry.
+
+## Apply / re-apply branch protection
+
+Don't restate the commands here. See
+[`docs/runbooks/branch-protection.md`](../docs/runbooks/branch-protection.md).
+The runbook covers Simple-profile (this repo) and Enterprise-profile
+snippets, tag protection for `v*`, and the Dependabot alerts toggle.
+
+## Investigate version drift
+
+1. Check the Renovate Dependency Dashboard (auto-issue opened by Renovate).
+2. The `check-updates.yml` workflow is the legacy fallback — it opens a
+   `chore: update plugin versions` PR weekly. If neither has surfaced
+   what you expect, the issue is in the upstream plugin (not tagged?
+   not a github release? the regex manager in `aida-core/.github`'s
+   `default.json` only matches `source.ref` to `github-releases`).
+3. Workflow dispatch manually: `gh workflow run check-updates.yml`.
+
+## Respond to a link-check failure
+
+1. The CI job names the broken link with its file + line.
+2. If it's an external link that died: update the link or remove it.
+3. If it's a self-reference (e.g., the marketplace `$schema` URL on a
+   schema-change PR): verify `lychee.toml`'s exclude list still covers
+   the pattern. The schema URL is `^https://raw.githubusercontent.com/aida-core/aida-marketplace/main/schemas/`.
+4. If it's a flake (rate limit, transient 5xx): lychee retries 3× — if
+   it still fails, push an empty commit or wait. If it's recurring,
+   tune `max_retries` / `max_concurrency` in `lychee.toml`.
+
+## Cut a release of the marketplace itself
+
+This is currently undocumented because the marketplace doesn't ship a
+versioned artifact — operators consume via `github>aida-core/aida-marketplace`
+refs. Tracking as follow-up [#77](https://github.com/aida-core/aida-marketplace/issues/77)
+(release workflow + SBOM).


### PR DESCRIPTION
## Summary

Closes #47. Two-layer pattern for contributor and Claude Code context.

| Layer | Purpose | Loading |
| --- | --- | --- |
| \`CLAUDE.md\` (root) | Identity, repo layout, hard rules, commands, knowledge map | Always loaded by Claude Code |
| \`knowledge/*.md\` | Progressive reference (workflows, tooling, troubleshooting, index) | Read via tool call when CLAUDE.md mentions a file |

## Reviewer feedback baked in

| Reviewer catch | Resolution |
| --- | --- |
| Loading mechanism misnamed | Corrected: Claude doesn't auto-load by frontmatter type. Frontmatter is for AIDA tooling; the knowledge map in CLAUDE.md is what makes the pattern work |
| Repo layout missing | Added to CLAUDE.md |
| \`governance.md\` duplicates \`docs/adr/README.md\` | Dropped |
| \`goals.md\` too thin | Folded into CLAUDE.md + \`index.md\` |
| Need real recipes, not placeholders | \`workflows.md\` ships with concrete recipes including the highest-priority rebuild flow (\`update-marketplace.ts\`) |
| Missing \`.claude-plugin/\` directory orientation | \`tooling.md\` opens with it |
| \`troubleshooting.md\` not in plan | Added — covers REUSE, frontmatter, lychee, validator/schema rules, signed commits, no-AI-coauthor, Renovate |
| SPDX headers | Present on all new files (HTML comments after frontmatter) |

## File list

- \`CLAUDE.md\` (5KB — a bit above the 2-3KB target, but every section serves a purpose)
- \`knowledge/index.md\`
- \`knowledge/workflows.md\`
- \`knowledge/tooling.md\`
- \`knowledge/troubleshooting.md\`
- \`CHANGELOG.md\`

4 knowledge files instead of original plan's 5 — \`governance.md\` and \`goals.md\` deliberately omitted per reviewer feedback.

## Local verification

- \`make lint-yaml\` ✓
- \`make validate-frontmatter\` ✓ (6 passing now, was 1 — all 5 new files pass)
- Longest line per file: under 240 chars (300 limit)

## Designed to be copied

aida-core-plugin will eventually scaffold marketplaces from this repo. The pattern (CLAUDE.md anatomy + 4-file knowledge structure + frontmatter shape) copies verbatim; content varies per repo. The workflow/tooling/troubleshooting split is the durable abstraction.

## Test plan

- [ ] CI green (TypeScript, Lint, No AI Co-Authors, Changelog, link-check pr-scope, Apply labels)
- [ ] \`make validate-frontmatter\` passes on the new files
- [ ] \`make lint-md\` passes (line length, blank lines around headings/lists)
- [ ] Spot-check: open a new Claude Code session on this repo, ask \"how do I add a new validator rule\" — Claude should read \`knowledge/workflows.md\`