### PR TITLE
docs: marketplace-specific issue templates (#79)

### DIFF
--- a/.github/ISSUE_TEMPLATE/adr-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/adr-proposal.yml
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
+---
+name: ADR proposal
+description: Propose a new Architecture Decision Record for the marketplace.
+title: "[ADR] <one-line decision summary>"
+labels: ["adr", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an ADR. ADRs record durable architectural decisions for the marketplace.
+
+        Read the [ADR index](https://github.com/aida-core/aida-marketplace/blob/main/docs/adr/README.md)
+        and the [template](https://github.com/aida-core/aida-marketplace/blob/main/docs/adr/0000-adr-template.md)
+        before filling this out. Per [#42](https://github.com/aida-core/aida-marketplace/issues/42),
+        new ADRs that establish manifest constraints also need a matching validator rule
+        — they land together in the same PR.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What's the problem? What forces are at play? Why is a decision needed now?
+      placeholder: |
+        State the situation, not the solution. Cite concrete examples or pain points.
+    validations:
+      required: true
+
+  - type: textarea
+    id: options
+    attributes:
+      label: Considered options
+      description: List the alternatives with honest pros/cons. Don't strawman the rejected options.
+      placeholder: |
+        1. Option A — one-sentence description.
+           - Pros: ...
+           - Cons: ...
+        2. Option B — ...
+        3. Option C — ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: Proposed decision
+      description: One sentence stating the choice, then why this option over the others.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: enforcement
+    attributes:
+      label: Enforcement mechanism
+      description: How will this decision be mechanically enforced (per the umbrella #42 governance pattern)?
+      options:
+        - Validator rule (in scripts/validate-marketplace.ts; tagged [ADR-NNNN])
+        - JSON Schema constraint (in schemas/marketplace.schema.json)
+        - CI workflow check (new workflow or step)
+        - GitHub-enforced (branch protection, CODEOWNERS, etc.)
+        - Documentation only (no mechanical enforcement)
+        - Other / unsure (explain below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: consequences
+    attributes:
+      label: Expected consequences
+      description: What changes if we adopt this? Both gains and accepted costs.
+      placeholder: |
+        Gained:
+        - ...
+        Accepted costs:
+        - ...
+
+  - type: input
+    id: related
+    attributes:
+      label: Related ADRs / issues
+      description: Comma-separated list of ADR numbers or issue references this interacts with.
+      placeholder: "ADR-0003, ADR-0007, #45"
+
+  - type: checkboxes
+    id: confirms
+    attributes:
+      label: Submission checklist
+      options:
+        - label: I've read the existing ADRs to confirm this isn't already decided or contradicted.
+          required: true
+        - label: I understand that "rule = ADR + check in same PR" — if this proposal becomes a validator rule, the PR landing it will also update the validator and tests.
+          required: true

--- a/.github/ISSUE_TEMPLATE/plugin-submission.yml
+++ b/.github/ISSUE_TEMPLATE/plugin-submission.yml
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
+---
+name: Plugin submission
+description: Propose a new plugin or guidebook for the marketplace catalog.
+title: "[plugin] <short-name>: one-line description"
+labels: ["plugin-change", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a new entry for the AIDA marketplace.
+
+        Please read [ADR-0003](https://github.com/aida-core/aida-marketplace/blob/main/docs/adr/0003-marketplace-entry-kinds.md)
+        (kind + repo suffix), [ADR-0005](https://github.com/aida-core/aida-marketplace/blob/main/docs/adr/0005-author-and-owner-identity.md)
+        (author identity), [ADR-0006](https://github.com/aida-core/aida-marketplace/blob/main/docs/adr/0006-semver-tag-refs.md)
+        (ref format), [ADR-0007](https://github.com/aida-core/aida-marketplace/blob/main/docs/adr/0007-category-allow-list.md)
+        (categories), and [ADR-0009](https://github.com/aida-core/aida-marketplace/blob/main/docs/adr/0009-aida-config-required.md)
+        (aida-config.json required) before submitting. The validator enforces these and will fail otherwise.
+
+  - type: input
+    id: repo
+    attributes:
+      label: Source repo (owner/name)
+      description: GitHub repo in `owner/name` form. Must end with `-plugin` or `-guidebook` per ADR-0003.
+      placeholder: "yourorg/your-thing-plugin"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      description: Per ADR-0003. Must match the repo suffix.
+      options:
+        - plugin
+        - guidebook
+    validations:
+      required: true
+
+  - type: input
+    id: ref
+    attributes:
+      label: Pinned ref (semver tag)
+      description: Per ADR-0006. Must match `v?\d+\.\d+\.\d+` — no branches, no SHAs, no pre-releases.
+      placeholder: "v1.0.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: Closed allow-list per ADR-0007.
+      options:
+        - core
+        - workflow
+        - infrastructure
+        - language
+        - integration
+        - domain
+        - productivity
+        - security
+        - observability
+    validations:
+      required: true
+
+  - type: input
+    id: author
+    attributes:
+      label: Author (GitHub slug)
+      description: Per ADR-0005 — GitHub org or user slug. No email, no URL.
+      placeholder: "yourorg"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: One- or two-sentence factual summary that will appear in the manifest.
+      placeholder: "What does this plugin/guidebook do?"
+    validations:
+      required: true
+
+  - type: input
+    id: tags
+    attributes:
+      label: Tags (comma-separated, kebab-case)
+      placeholder: "kebab-case, lower-case, comma-separated"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: conformance
+    attributes:
+      label: Conformance checklist
+      description: All items must be true at the pinned ref before this can be added.
+      options:
+        - label: The source repo's name ends with the matching suffix (`-plugin` or `-guidebook`).
+          required: true
+        - label: The source repo ships `.claude-plugin/aida-config.json` at the pinned ref (ADR-0009). N/A only for `aida-core/aida-core-plugin` (the foundation).
+          required: true
+        - label: I have read the relevant ADRs linked above and understand the marketplace's hard rules.
+          required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- `.github/ISSUE_TEMPLATE/plugin-submission.yml` — structured
+  GitHub issue form for proposing a new plugin or guidebook.
+  Captures repo URL, kind, pinned ref, category, author slug,
+  description, tags, and a conformance checklist tied to the
+  relevant ADRs (0003, 0005, 0006, 0007, 0009). Auto-applies
+  `plugin-change` + `needs-triage` labels. Filed from #79.
+- `.github/ISSUE_TEMPLATE/adr-proposal.yml` — structured ADR
+  proposal form mirroring `docs/adr/0000-adr-template.md`:
+  context, considered options, proposed decision, enforcement
+  mechanism (dropdown matching the available enforcement
+  surfaces), consequences, related ADRs. Auto-applies `adr` +
+  `needs-triage` labels. Filed from #79.
+- Both templates complement the org-level `bug_report.yml` and
+  `feature_request.yml` in `aida-core/.github/ISSUE_TEMPLATE/`
+  rather than replacing them.
 - `CLAUDE.md` at the repo root — Claude Code project memory.
   Identity, repo layout, hard rules summarized from accepted
   ADRs 0001–0010, command reference, and a `knowledge/` map


### PR DESCRIPTION
## Summary

Closes #79. Adds two structured GitHub issue forms.

| Template | Auto-labels | Purpose |
| --- | --- | --- |
| \`plugin-submission.yml\` | \`plugin-change\`, \`needs-triage\` | Propose a new plugin or guidebook for the marketplace. Captures repo, kind, ref, category, author, tags, plus a conformance checklist tied to ADRs 0003/0005/0006/0007/0009. |
| \`adr-proposal.yml\` | \`adr\`, \`needs-triage\` | Propose a new ADR. Mirrors the ADR template (context / options / decision / enforcement / consequences). The enforcement dropdown nudges proposers toward thinking about mechanical enforcement per #42. |

## Complements (doesn't replace) org templates

\`aida-core/.github/ISSUE_TEMPLATE/\` provides \`bug_report.yml\`, \`feature_request.yml\`, and \`config.yml\` (which disables blank issues and routes security/support). Marketplace-specific templates layer on top.

## Test plan

- [ ] CI green (yamllint on the new YAML, REUSE headers, link-check on the ADR URLs)
- [ ] After merge: visit the issue creation page; both new templates should appear alongside the org ones
- [ ] Spot-check: confirm \`plugin-change\` and \`adr\` labels exist (they do, created in #72)