### PR TITLE
chore(ci): validate CODEOWNERS on every PR (#81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,25 @@ jobs:
       - name: Validate markdown frontmatter
         run: make validate-frontmatter
 
+      - name: Validate CODEOWNERS
+        env:
+          # gh api needs auth to read the codeowners/errors endpoint.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # A malformed CODEOWNERS silently disables code-owner-review
+          # enforcement (per ADR-0010). Surface errors at PR time so they
+          # don't accumulate. Returns errors[] in the response body; empty
+          # array means the file is valid.
+          errors_count=$(gh api "repos/${GITHUB_REPOSITORY}/codeowners/errors" \
+            --jq '.errors | length')
+          if [ "$errors_count" -gt 0 ]; then
+            echo "::error::CODEOWNERS has $errors_count errors:"
+            gh api "repos/${GITHUB_REPOSITORY}/codeowners/errors" \
+              --jq '.errors[] | "\(.path):\(.line // 0): \(.kind) — \(.message)"'
+            exit 1
+          fi
+          echo "CODEOWNERS is valid (0 errors)."
+
   changelog:
     name: Changelog
     if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- CI: `Validate CODEOWNERS` step in the `Lint` job. Calls
+  `gh api repos/${{ github.repository }}/codeowners/errors` and
+  fails the job if the returned `errors[]` array is non-empty.
+  No third-party action dependency. Closes #81 — addresses the
+  drift concern ADR-0010 flagged ("a malformed CODEOWNERS
+  silently disables code-owner-review enforcement").
 - `.github/ISSUE_TEMPLATE/plugin-submission.yml` — structured
   GitHub issue form for proposing a new plugin or guidebook.
   Captures repo URL, kind, pinned ref, category, author slug,


### PR DESCRIPTION
## Summary

Closes #81. Adds a \`Validate CODEOWNERS\` step to the existing \`Lint\` job.

## What it does

Calls \`gh api repos/{owner}/{repo}/codeowners/errors\` and fails the job if any errors are returned. No third-party action dependency.

A malformed CODEOWNERS silently disables code-owner-review enforcement (per ADR-0010). This now gets caught at PR time before merge.

## What it catches

- Referenced GitHub user or team that doesn't exist
- Unrecognized pattern syntax
- File unreadable or missing

## What it doesn't catch (out of scope)

- Stale users who still exist but no longer maintain
- Sole-owner deadlock (ADR-0010's "flip \`require_code_owner_reviews\` → true once CODEOWNERS has 2+ entries" is still a manual decision)

## Test plan

- [ ] CI green on this PR (current CODEOWNERS is valid; step exits 0)
- [ ] Post-merge: introduce a deliberately-broken CODEOWNERS on a scratch branch (e.g., reference a non-existent user) and confirm the step fails with the error details