### PR TITLE
docs: ADR-0011 — decline local commit hooks (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- ADR-0011: decline local commit hooks (`pre-commit`, `lefthook`,
+  `husky`) in favor of `make lint` + fast CI. Records the
+  deferral with named re-open triggers (contributor volume,
+  CI latency, repeated fixup commits, or a scaffolded marketplace
+  adopting hooks first). Documentation-driven; no validator rule
+  to enforce. Closes #78.
 - CI: `Validate CODEOWNERS` step in the `Lint` job. Calls
   `gh api repos/${{ github.repository }}/codeowners/errors` and
   fails the job if the returned `errors[]` array is non-empty.

--- a/docs/adr/0011-local-commit-hooks.md
+++ b/docs/adr/0011-local-commit-hooks.md
@@ -1,0 +1,102 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0011: Decline local commit hooks (rely on `make lint` + CI)
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Filed from:** [#78](https://github.com/aida-core/aida-marketplace/issues/78)
+
+## Context
+
+A common contributor-ergonomics pattern is local git commit hooks
+(`pre-commit`, `lefthook`, `husky`) that run linters before a commit
+lands. The value proposition is faster feedback — catch problems before
+push instead of after CI runs.
+
+This repo's current state:
+
+- All checks already run in CI on every PR (~30s for the Lint job, ~15s
+  for TypeScript). The feedback delta a pre-commit hook would save is
+  small.
+- `make lint` is the documented local path; it runs the same checks CI
+  runs. Contributors who want pre-push feedback already have it.
+- The repo has 4 devDependencies (`ajv`, `tsx`, `typescript`,
+  `@types/node`) and a small contributor base. Hooks solve "team-scaling"
+  problems we don't yet have.
+- The toolchain is hybrid Node + Python (`yamllint`, `reuse`,
+  `jsonschema`, `PyYAML`). A hook framework would need to bridge both.
+
+## Considered options
+
+1. **`pre-commit`** (Python framework, `.pre-commit-config.yaml`)
+   - Pros: handles Python + Node tools uniformly; large ecosystem of
+     pre-built hooks.
+   - Cons: adds a Python framework on top of an already-Python-tooled
+     venv; duplicates `make lint`; contributors must run
+     `pre-commit install` once.
+
+2. **`lefthook`** (Go binary, `lefthook.yml`)
+   - Pros: zero-dep binary; fast; idiomatic for Node-first repos.
+   - Cons: still requires `lefthook install`; new binary on every
+     contributor's machine; doesn't natively handle the Python lint
+     half.
+
+3. **`husky`** (Node, `.husky/`)
+   - Pros: npm-native; integrates cleanly with the Node toolchain.
+   - Cons: awkward for the Python lint half; ~6 transitive deps.
+
+4. **Decline adoption** — rely on `make lint` + fast CI.
+   - Pros: no new contributor onboarding step; no new dependency; no
+     drift between local hooks and CI; CI remains the single source of
+     truth for what's required.
+   - Cons: contributors who don't run `make lint` before pushing find
+     out about issues 30 seconds later in CI.
+
+## Decision
+
+Adopt **option 4: decline local commit hooks** for now.
+
+`make lint` is already the documented local path. CI is fast. Adding a
+hook framework would create a *parallel* place where lint rules live
+that has to stay in sync with the Makefile and CI. The cost of that
+drift is real; the benefit (saving ~30s of CI feedback latency) is
+marginal at this repo's scale.
+
+This ADR is documentation-driven — there is no validator rule to add.
+It records the deferral so the question doesn't get re-raised without
+new evidence.
+
+### Named re-open triggers
+
+Revisit this decision when ANY of the following becomes true:
+
+1. **Contributor volume.** Three or more active contributors landing
+   more than five PRs per month.
+2. **CI latency.** The Lint or TypeScript job p50 exceeds 2 minutes.
+3. **Repeated fixup commits.** A single contributor lands three or more
+   lint-only fixup commits in a single month.
+4. **A scaffolded marketplace adopts hooks first** and the pattern
+   proves itself there — `aida-marketplace` follows.
+
+## Consequences
+
+**Gained:**
+
+- Zero new dependency surface; zero new contributor onboarding step.
+- `make lint` remains the single local path, kept in sync by being the
+  same target CI runs.
+- Reference-implementation paper trail: a downstream marketplace
+  scaffolded from this repo gets a clear "we evaluated and declined"
+  rather than a stale opt-out comment.
+
+**Accepted costs:**
+
+- Contributors who don't run `make lint` before pushing learn about
+  issues from CI (~30s later) rather than from a hook (~immediately).
+
+## Enforcement
+
+Documentation-driven. No validator rule, no CI gate. If a hook is
+added without flipping this ADR to Superseded, that's a review-time
+signal that the named triggers have been hit.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@ See [`0000-adr-template.md`](./0000-adr-template.md). Copy it, rename, fill in.
 | 0008 | [JSON Schema as the canonical structural definition](./0008-json-schemas.md) | Accepted | [#50](https://github.com/aida-core/aida-marketplace/issues/50) |
 | 0009 | [Listed plugins must ship `.claude-plugin/aida-config.json`](./0009-aida-config-required.md) | Accepted | [#44](https://github.com/aida-core/aida-marketplace/issues/44) |
 | 0010 | [Branch protection baseline](./0010-branch-protection-baseline.md) | Accepted | [#49](https://github.com/aida-core/aida-marketplace/issues/49) |
+| 0011 | [Decline local commit hooks](./0011-local-commit-hooks.md) | Accepted | [#78](https://github.com/aida-core/aida-marketplace/issues/78) |


### PR DESCRIPTION
## Summary

Closes #78. Records the decision to NOT adopt local commit hooks (\`pre-commit\` / \`lefthook\` / \`husky\`) for this repo.

## Why decline

- 4 devDependencies, solo-maintained, no contributor volume problem yet
- \`make lint\` is already the documented local path; CI is fast (~30s lint)
- Hooks would create a parallel place where lint rules live with drift risk against the Makefile and CI
- Hybrid Node + Python toolchain makes every hook framework less clean

## Named re-open triggers (in the ADR)

Revisit if any becomes true:

1. 3+ active contributors landing 5+ PRs/month
2. CI Lint or TypeScript p50 > 2 minutes
3. A single contributor lands 3+ lint-only fixup commits in a month
4. A scaffolded downstream marketplace adopts hooks first

## Why an ADR for a non-adoption decision

This is the canonical reference marketplace. A scaffolded downstream gets clear "we evaluated and declined" rather than re-relitigating the question. Matches the ADR-0004 "defer with documented triggers" pattern.

## Test plan

- [ ] CI green (this is doc-only)
- [ ] \`docs/adr/README.md\` lists the new ADR