### PR TITLE
feat(ci): npm audit blocking gate + ADR-0012 (#76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,25 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run check
 
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      # --ignore-scripts: don't run install hooks during a security check.
+      - run: npm ci --ignore-scripts
+
+      # `npm audit` against the committed lockfile. Blocks on high or
+      # critical advisories. Renovate's CVE auto-merge clears the gate
+      # automatically when it lands a fix. See ADR-0012 for the policy.
+      - name: npm audit (high+)
+        run: npm audit --audit-level=high --omit=optional
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- ADR-0012: supply-chain audit policy. Adds a blocking `Audit`
+  CI job running `npm audit --audit-level=high --omit=optional`
+  on every PR and push to `main`. Pairs with the existing
+  CVE-handling stack (Renovate auto-merge for patch+minor,
+  Dependabot alerts) — fills the PR-time blocking gap. Allowlist
+  mechanism deferred (YAGNI; npm `overrides` is the preferred
+  remediation; Renovate's CVE PRs typically clear the gate
+  automatically). Closes #76.
+- `Audit` added to ADR-0010's required-status-check baseline and
+  to the branch-protection runbook's `gh api` snippet.
 - ADR-0011: decline local commit hooks (`pre-commit`, `lefthook`,
   `husky`) in favor of `make lint` + fast CI. Records the
   deferral with named re-open triggers (contributor volume,

--- a/docs/adr/0010-branch-protection-baseline.md
+++ b/docs/adr/0010-branch-protection-baseline.md
@@ -73,7 +73,8 @@ These apply to `main` regardless of profile:
 Required status check contexts (workflow job names that GitHub gates on):
 
 - `TypeScript` (typecheck + tests + validator + version check)
-- `Lint` (yaml + md + json + REUSE + frontmatter)
+- `Lint` (yaml + md + json + REUSE + frontmatter + CODEOWNERS)
+- `Audit` (`npm audit --audit-level=high`; per [ADR-0012](./0012-supply-chain-audit-policy.md))
 - `No AI Co-Authors`
 - `Changelog`
 - `PR scope (changed markdown only)` (link-check on PRs)

--- a/docs/adr/0012-supply-chain-audit-policy.md
+++ b/docs/adr/0012-supply-chain-audit-policy.md
@@ -1,0 +1,131 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0012: Supply-chain audit policy (`npm audit` in CI)
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Filed from:** [#76](https://github.com/aida-core/aida-marketplace/issues/76)
+
+## Context
+
+The marketplace already has multiple CVE-handling surfaces:
+
+- **Renovate** opens version bumps weekly; CVE patches auto-merge for
+  trusted-source minor/patch updates (ADR-0002).
+- **Dependabot vulnerability alerts** surface GHSA-database advisories
+  (notifications-only; not PR-producing).
+- **`minimumReleaseAge: "14 days"`** + **`minimumConfidence: "high"`**
+  gate routine npm dep updates org-wide.
+
+What's missing is a **blocking PR-time gate**: a direct contributor
+could land a PR adding a vulnerable dep before Renovate's next cycle
+catches it. Or a transitive dep could carry a newly-published advisory
+that none of the *update*-triggered tools see (Renovate fires on dep
+changes; advisories on unchanged lockfiles don't trigger it).
+
+`npm audit` against the committed lockfile fills that gap.
+
+## Considered options
+
+1. **No audit** — rely on Renovate + Dependabot alerts as today.
+   - Pros: zero added CI surface.
+   - Cons: latency window between when an advisory publishes and when
+     Renovate catches it; direct contributors can land vulnerable deps
+     un-gated.
+
+2. **`npm audit` warn-only annotation** — runs in CI, never fails.
+   - Pros: information without friction.
+   - Cons: warnings become invisible. Quality gates need teeth.
+
+3. **`npm audit --audit-level=high` blocking** — fails the PR on any
+   high or critical advisory against direct or transitive deps.
+   - Pros: actual gate; Renovate's CVE PRs naturally clear it; pairs
+     well with the existing supply-chain stack.
+   - Cons: when a transient false-positive or "accepted-risk" CVE
+     surfaces, the operator has to fix or work around it (npm has no
+     first-class allowlist).
+
+4. **External scanner** (`socket.dev`, `osv-scanner`) — heavier,
+   external service.
+   - Pros: richer signal (typosquats, malicious patterns, beyond CVE).
+   - Cons: external dependency, more setup, signal/noise tradeoff for
+     a small repo.
+
+## Decision
+
+Adopt **option 3: `npm audit --audit-level=high` as a blocking CI job.**
+
+- New `Audit` job in `.github/workflows/ci.yml`. Runs on PR and on
+  push to `main`.
+- Command: `npm audit --audit-level=high --omit=optional`.
+  - `--audit-level=high` blocks on high or critical; ignores
+    moderate/low (npm's moderate has notorious false-positive rate for
+    devDeps).
+  - `--omit=optional` skips optional deps — they're not in the install
+    path for CI runs.
+  - Production AND devDeps are audited; devDeps run in CI with
+    `GITHUB_TOKEN` so a compromised `tsx`/`ajv`/etc. is in scope.
+- `Audit` is added to the Simple-profile required-status-checks list
+  in [ADR-0010](./0010-branch-protection-baseline.md) and the
+  [branch-protection runbook](../runbooks/branch-protection.md).
+
+### Allowlist mechanism — deferred until needed
+
+npm has no first-class audit ignore. When a high+ advisory surfaces:
+
+1. **Preferred path:** bump the offending dep, or pin via
+   `package.json` `overrides` to a patched version. Renovate's CVE
+   auto-merge usually does this within hours/days of the advisory
+   publishing.
+2. **If no fix exists:** discuss in the PR. If genuinely
+   accepted-risk, the team can either bump `--audit-level=critical`
+   temporarily (loses granularity) OR implement a custom allowlist
+   tool. The custom tool is deferred — current devDep count (4) and
+   solo maintainer state make the YAGNI case strong. File a follow-up
+   if/when a real accepted-risk CVE appears.
+
+### Interaction with the rest of the supply-chain stack
+
+| Surface | Trigger | Action | Latency |
+| --- | --- | --- | --- |
+| Renovate CVE auto-merge | New patch+minor release | Open PR, auto-merge after CI | hours |
+| Dependabot alerts | New GHSA advisory | Notification only | minutes |
+| **`Audit` job (this ADR)** | Every PR + push | Block merge if high+ CVE | per-PR |
+
+No conflict. A Renovate CVE PR that bumps the vulnerable dep makes
+`Audit` go green on the same PR.
+
+## Consequences
+
+**Gained:**
+
+- PR-time blocking gate. A vulnerable dep can't land while the advisory
+  is open.
+- Pairs naturally with Renovate's CVE PRs — they auto-clear the gate.
+- Reference-implementation paper trail: scaffolded marketplaces have
+  a documented audit policy to inherit.
+
+**Accepted costs:**
+
+- One additional required CI check (`Audit`) added to ADR-0010's
+  baseline.
+- A transient or accepted-risk CVE could block PRs until the team
+  decides how to handle it (allowlist deferred to follow-up).
+- Slight CI run-time addition (~5-10s for `npm audit` on this repo's
+  lockfile).
+
+## Enforcement
+
+- New `Audit` job in `.github/workflows/ci.yml`. Job name `Audit` is the
+  required-status-check string in branch protection.
+- Add `Audit` to [ADR-0010](./0010-branch-protection-baseline.md)
+  baseline's required-checks list AND to the runbook's
+  `required_status_checks.contexts` array. Apply the updated
+  branch-protection payload after merging this ADR's PR.
+- No validator rule needed; this is a CI-enforced policy.
+
+**Follow-up:** if/when an accepted-risk transitive CVE surfaces and the
+preferred remediation (override) is unavailable, file an issue to add a
+formal allowlist mechanism (e.g., `audit-allowlist.json` + a
+`scripts/audit-ci.ts` filter). Until then, YAGNI.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,3 +42,4 @@ See [`0000-adr-template.md`](./0000-adr-template.md). Copy it, rename, fill in.
 | 0009 | [Listed plugins must ship `.claude-plugin/aida-config.json`](./0009-aida-config-required.md) | Accepted | [#44](https://github.com/aida-core/aida-marketplace/issues/44) |
 | 0010 | [Branch protection baseline](./0010-branch-protection-baseline.md) | Accepted | [#49](https://github.com/aida-core/aida-marketplace/issues/49) |
 | 0011 | [Decline local commit hooks](./0011-local-commit-hooks.md) | Accepted | [#78](https://github.com/aida-core/aida-marketplace/issues/78) |
+| 0012 | [Supply-chain audit policy](./0012-supply-chain-audit-policy.md) | Accepted | [#76](https://github.com/aida-core/aida-marketplace/issues/76) |

--- a/docs/runbooks/branch-protection.md
+++ b/docs/runbooks/branch-protection.md
@@ -40,6 +40,7 @@ The strings in `required_status_checks.contexts` must match the workflow
 | --- | --- |
 | `TypeScript` | `.github/workflows/ci.yml` (typecheck job) |
 | `Lint` | `.github/workflows/ci.yml` (lint job) |
+| `Audit` | `.github/workflows/ci.yml` (audit job — per ADR-0012) |
 | `Changelog` | `.github/workflows/ci.yml` (changelog job) |
 | `No AI Co-Authors` | `.github/workflows/no-ai-coauthor.yml` |
 | `PR scope (changed markdown only)` | `.github/workflows/link-check.yml` (pr-scope job) |
@@ -66,6 +67,7 @@ gh api -X PUT repos/aida-core/aida-marketplace/branches/main/protection \
     "contexts": [
       "TypeScript",
       "Lint",
+      "Audit",
       "No AI Co-Authors",
       "Changelog",
       "PR scope (changed markdown only)"
@@ -113,6 +115,7 @@ gh api -X PUT repos/<OWNER>/<REPO>/branches/main/protection \
     "contexts": [
       "TypeScript",
       "Lint",
+      "Audit",
       "No AI Co-Authors",
       "Changelog",
       "PR scope (changed markdown only)"


### PR DESCRIPTION
## Summary

Closes #76. Adds a blocking \`Audit\` CI job + ADR-0012 documenting the policy.

## Why now

Renovate handles CVE PRs (auto-merge patch+minor for trusted sources) and Dependabot alerts surface GHSA advisories, but **neither blocks merge** on a known-vulnerable lockfile. A direct contributor could land a vulnerable dep before Renovate catches it. This \`Audit\` job is the PR-time gate.

## Policy decisions (in ADR-0012)

| Decision | Choice | Why |
| --- | --- | --- |
| audit-level | \`high\` | Blocks high+critical; moderate/low ignored (devDep FP rate) |
| --omit=optional | yes | Optional deps not in CI install path |
| prod + devDeps | both audited | DevDeps run with GITHUB_TOKEN — in-scope |
| Block vs warn | block | Warnings become invisible; this is a gate |
| Allowlist | **deferred** | YAGNI; \`npm overrides\` is the preferred remediation; Renovate's CVE PRs usually clear the gate |

## Interaction with the existing stack

| Surface | Trigger | Action | Latency |
| --- | --- | --- | --- |
| Renovate CVE auto-merge | New patch+minor release | Auto-merge after CI | hours |
| Dependabot alerts | New GHSA advisory | Notification only | minutes |
| **\`Audit\` (this PR)** | Every PR + push | Block merge if high+ CVE | per-PR |

No conflict. A Renovate CVE PR that bumps the vulnerable dep makes \`Audit\` go green on the same PR.

## Branch protection updates

\`Audit\` is added to ADR-0010's required-status-checks list and to the runbook's \`gh api\` payload. After merge, re-apply the Simple-profile snippet from the runbook to actually gate on the new check.

## Local verification

\`\`\`
\$ npm audit --audit-level=high --omit=optional
found 0 vulnerabilities
\`\`\`

## Test plan

- [ ] CI green (current lockfile is clean)
- [ ] Post-merge: re-apply branch-protection runbook so \`Audit\` becomes required
- [ ] Spot-check: introduce a known-vulnerable transitive on a scratch branch (e.g., via \`overrides\` pinning to a yanked patch) and confirm \`Audit\` fails