### PR TITLE
feat: marketplace release workflow + SBOM (#77, ADR-0013)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+# SPDX-License-Identifier: MPL-2.0
+
+---
+name: Release
+
+# Tag-triggered. The maintainer pushes a signed v* tag (per the runbook)
+# and this workflow takes over: re-runs CI gates, generates artifacts,
+# publishes a GitHub Release. See ADR-0013 for the release model.
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to create the GitHub Release and upload assets.
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0 # extract-changelog needs the full history
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      - run: npm ci --ignore-scripts
+
+      # --- Gates: re-run CI before publishing the release ---
+
+      - name: Re-run validator (ADR-0001)
+        run: npm run validate
+
+      - name: Re-run plugin version check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run check
+
+      - name: Re-run npm audit (ADR-0012)
+        run: npm audit --audit-level=high --omit=optional
+
+      # --- Assert marketplace.json#version matches the tag (ADR-0013) ---
+
+      - name: Assert manifest version matches tag
+        id: version
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          tag_version="${tag#v}"
+          manifest_version=$(node -e \
+            "process.stdout.write(require('./.claude-plugin/marketplace.json').version)")
+          if [ "$tag_version" != "$manifest_version" ]; then
+            echo "::error::tag ${tag} → ${tag_version}, but marketplace.json#version is ${manifest_version}." \
+              "Bump marketplace.json#version in a PR before tagging."
+            exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${tag_version}" >> "$GITHUB_OUTPUT"
+
+      # --- Generate release artifacts ---
+
+      - name: Generate plugin-pins.json
+        run: |
+          node -e "
+            const m = require('./.claude-plugin/marketplace.json');
+            const pins = m.plugins.map(p => ({
+              name: p.name,
+              repo: p.source.repo,
+              ref: p.source.ref,
+              version: p.version,
+            }));
+            require('fs').writeFileSync('plugin-pins.json',
+              JSON.stringify(pins, null, 2) + '\n');
+          "
+
+      - name: Generate SBOM (CycloneDX 1.6 JSON)
+        # @cyclonedx/cyclonedx-npm reads package-lock.json; produces an SBOM
+        # of the validator's own supply chain (the security-relevant surface
+        # for this metadata-only marketplace). Pinned via `npx` to a specific
+        # version so the release is reproducible.
+        run: |
+          npx --yes @cyclonedx/cyclonedx-npm@^4.0.0 \
+            --spec-version 1.6 \
+            --output-format json \
+            --output-file sbom.cdx.json
+
+      # --- Extract release notes from CHANGELOG ---
+
+      - name: Extract CHANGELOG section
+        run: |
+          npx tsx scripts/extract-changelog.ts "${{ steps.version.outputs.version }}" \
+            > release-notes.md
+          echo "Release notes preview:"
+          head -40 release-notes.md
+
+      # --- Publish ---
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          body_path: release-notes.md
+          fail_on_unmatched_files: true
+          files: |
+            .claude-plugin/marketplace.json
+            plugin-pins.json
+            sbom.cdx.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- ADR-0013: marketplace release model. Manual semver tag at
+  maintainer discretion, asserting `marketplace.json#version`
+  matches the tag. Bump policy: patch = plugin patch/minor only;
+  minor = new plugin or consumer-visible ADR; major = breaking
+  schema change or plugin removal. Closes #77.
+- `.github/workflows/release.yml` — tag-triggered release
+  workflow (`push: tags: ['v*.*.*']`). Re-runs validator + plugin
+  version check + `npm audit`, asserts manifest version matches
+  the tag, generates 3 artifacts and creates a GitHub Release.
+- Release artifacts attached on every `v*` release:
+  - `marketplace.json` — verbatim manifest snapshot
+  - `plugin-pins.json` — derived `{name, repo, ref, version}[]`
+    for the audit lane (diffable between releases)
+  - `sbom.cdx.json` — CycloneDX 1.6 SBOM of the marketplace's
+    own dependency tree (the validator's supply chain). Generated
+    via `@cyclonedx/cyclonedx-npm` (npx, no devDep addition).
+- `scripts/extract-changelog.ts` — line-based parser that pulls
+  a CHANGELOG section by version string. Used by `release.yml`
+  to populate the GitHub Release body. 5 unit tests covering
+  Unreleased, versioned, final-in-file, missing-section, and
+  regex-metachar-escaping cases.
+- `docs/runbooks/release.md` — operational runbook with the
+  pre-release checklist, tag-and-push sequence, what the workflow
+  does, and the common-scenario answers (version-mismatch fix,
+  Renovate races, hotfix flow, SBOM transient failures, why we
+  don't use workflow_dispatch).
 - `repository_dispatch` trigger on `.github/workflows/check-updates.yml`
   for event type `plugin-released`. Lets plugin repos optionally send
   an instant-bump signal that bypasses Renovate's Monday cadence by

--- a/docs/adr/0013-marketplace-release-model.md
+++ b/docs/adr/0013-marketplace-release-model.md
@@ -1,0 +1,133 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0013: Marketplace release model
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Filed from:** [#77](https://github.com/aida-core/aida-marketplace/issues/77)
+
+## Context
+
+`marketplace.json` carries a top-level `"version"` field (currently
+`"0.2.0"`). The marketplace is consumed via
+`github>aida-core/aida-marketplace` refs — there's no published artifact
+beyond the git tree itself. That works for the install lane (consumers
+track `main`), but it doesn't address the audit lane: regulated downstream
+operators and supply-chain reviewers need a "what was the registry at
+moment X" artifact they can pin to and diff against.
+
+[ADR-0006](./0006-semver-tag-refs.md) enforces semver tags on plugin
+`source.ref` values. The same discipline naturally extends to the
+marketplace's own version. [ADR-0010](./0010-branch-protection-baseline.md)
+already protects `v*` tags from rewrite/deletion. What's missing is the
+workflow that turns a `v*` tag push into an immutable audit artifact.
+
+## Considered options
+
+1. **No releases** — keep `version` as a soft field; consumers always
+   track `main`.
+   - Pros: zero added CI surface; no tag-vs-manifest coordination.
+   - Cons: no audit artifact; `version` field becomes a lie that
+     nobody verifies; regulated downstreams must re-invent this.
+
+2. **Auto-tag on every Renovate merge** — every plugin bump produces a
+   new marketplace patch release.
+   - Pros: fully automatic; consumers can pin to fresh tags.
+   - Cons: tag spam; the "release" loses signal value when every
+     Renovate PR creates one; high coordination cost with
+     branch-protection / required-signatures.
+
+3. **Manual semver tag at maintainer discretion** — maintainer cuts
+   a release when the manifest state is worth pinning.
+   - Pros: tag = real signal; bump policy ties to ADR-0006 semver
+     discipline; reuses existing CHANGELOG flow.
+   - Cons: depends on maintainer judgment; no fixed cadence.
+
+4. **Periodic snapshots** (weekly cron tags).
+   - Pros: fixed cadence; predictable for auditors.
+   - Cons: no signal value; tags accumulate fast; awkward for
+     downstreams who want to pin meaningful snapshots.
+
+## Decision
+
+Adopt **option 3: manual semver tag at maintainer discretion**.
+
+### Release shape
+
+A release is a git tag `v<X>.<Y>.<Z>` on `main` plus a GitHub Release
+containing three artifacts:
+
+1. **`marketplace.json`** — verbatim snapshot of the registry at the tag.
+2. **`plugin-pins.json`** — derived array of
+   `{name, repo, ref, version}` for each listed plugin. One file, one
+   line per plugin, sortable and diffable between releases.
+3. **`sbom.cdx.json`** — CycloneDX 1.6 SBOM of the marketplace's own
+   `package-lock.json` (the validator's supply chain).
+
+### Bump policy
+
+- **patch** (`v0.2.0 → v0.2.1`): plugin patch/minor bumps only; no
+  new plugins, no ADR-driven schema changes.
+- **minor** (`v0.2.0 → v0.3.0`): a new plugin or guidebook is added,
+  an ADR with consumer-visible effect ships, or a plugin's major bump
+  is pinned.
+- **major** (`v0.2.0 → v1.0.0`): a breaking change to
+  `marketplace.json` shape (new required field, removed field), or
+  removal of a previously-listed plugin.
+
+### Constraints
+
+- `marketplace.json#version` MUST equal the tag's version (the tag's
+  leading `v` is stripped for comparison). The release workflow
+  asserts this and fails loudly with a fix-up hint if they diverge.
+- Pre-release tags (`v0.3.0-rc1`) are NOT used for the marketplace
+  itself — ADR-0006 forbids them for plugin refs and the same
+  discipline applies here. Cut release candidates as separate
+  branches if needed; tag only finals.
+- Tag protection (per ADR-0010) prevents rewrites/deletions of `v*`
+  once an SBOM has been published referencing them.
+
+### Workflow gates (run before publishing the release)
+
+The release workflow re-runs the validator (per ADR-0001), the plugin
+version check, and `npm audit` (per ADR-0012). A tagged release that
+fails CI is the failure mode worth blocking on.
+
+## Consequences
+
+**Gained:**
+
+- Regulated downstream operators have a stable pin target +
+  diffable SBOM.
+- `version` field becomes verifiable rather than aspirational.
+- Reference-implementation pattern: scaffolded downstream
+  marketplaces inherit a working release pipeline.
+- CHANGELOG `[Unreleased]` flow stays meaningful — releases
+  trigger the flip to a versioned section.
+
+**Accepted costs:**
+
+- Tag-push discipline (sign the tag, push to origin, wait for
+  workflow). Documented in [`docs/runbooks/release.md`](../runbooks/release.md).
+- One additional workflow to maintain (`.github/workflows/release.yml`).
+- SBOM and plugin-pins artifacts must be regenerated on every release —
+  no caching across releases.
+
+## Enforcement
+
+- **Workflow gate:** `release.yml` triggers on `push: tags: ['v*.*.*']`.
+  Re-runs validator + version-check + audit before publishing.
+- **Version-match assertion:** workflow fails if
+  `marketplace.json#version` doesn't match the tag.
+- **Tag protection:** already enabled via ADR-0010 — tags can't be
+  rewritten or deleted once landed.
+- **Runbook:** [`docs/runbooks/release.md`](../runbooks/release.md)
+  with literal `git tag -s ... && git push` sequence and pre-release
+  checklist (flip `[Unreleased]` → `[v<X>.<Y>.<Z>]` in the same PR
+  that bumps `marketplace.json#version`).
+
+The release artifact set (`marketplace.json` + `plugin-pins.json` +
+`sbom.cdx.json`) is the contract. Downstream consumers can rely on it
+being present on every `v*` release; scaffolded marketplaces should
+mirror it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,4 @@ See [`0000-adr-template.md`](./0000-adr-template.md). Copy it, rename, fill in.
 | 0010 | [Branch protection baseline](./0010-branch-protection-baseline.md) | Accepted | [#49](https://github.com/aida-core/aida-marketplace/issues/49) |
 | 0011 | [Decline local commit hooks](./0011-local-commit-hooks.md) | Accepted | [#78](https://github.com/aida-core/aida-marketplace/issues/78) |
 | 0012 | [Supply-chain audit policy](./0012-supply-chain-audit-policy.md) | Accepted | [#76](https://github.com/aida-core/aida-marketplace/issues/76) |
+| 0013 | [Marketplace release model](./0013-marketplace-release-model.md) | Accepted | [#77](https://github.com/aida-core/aida-marketplace/issues/77) |

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -1,0 +1,130 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Runbook: cut a marketplace release
+
+Operational reference for [ADR-0013](../adr/0013-marketplace-release-model.md).
+Releases are manual, semver-tagged, and produce three artifacts attached
+to a GitHub Release.
+
+## Prerequisites
+
+- You're the marketplace **Owner** (per `MAINTAINERS.md`).
+- Signed-commit setup per GitHub's
+  [docs](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+  Tag protection on `v*` (per ADR-0010) doesn't enforce signing on tags
+  directly, but the practice matters for the audit lane.
+- Local clone on `main` is up-to-date.
+
+## Pre-release checklist
+
+Decide the bump per [ADR-0013](../adr/0013-marketplace-release-model.md):
+
+- **patch** (`v0.2.0 → v0.2.1`) — plugin patch/minor bumps only
+- **minor** (`v0.2.0 → v0.3.0`) — new plugin, ADR with consumer-visible
+  effect, or plugin major bump
+- **major** (`v0.2.0 → v1.0.0`) — breaking schema change or plugin removal
+
+Pre-release PR:
+
+1. Edit `.claude-plugin/marketplace.json` — bump the top-level
+   `"version"` to the target version (no `v` prefix; the string).
+2. Edit `CHANGELOG.md` — rename `## [Unreleased]` to
+   `## [<X>.<Y>.<Z>] - YYYY-MM-DD`. Leave `## [Unreleased]` heading
+   above with empty `### Added` / `### Changed` / `### Removed`
+   subsections for the next cycle.
+3. Open PR, get CI green, merge.
+
+## Tag the release
+
+After the pre-release PR merges:
+
+```bash
+git checkout main
+git pull --ff-only
+
+# Tag the release commit. Sign it (GPG or SSH).
+git tag -s "v<X>.<Y>.<Z>" -m "Release v<X>.<Y>.<Z>"
+
+# Push the tag. Triggers .github/workflows/release.yml.
+git push origin "v<X>.<Y>.<Z>"
+```
+
+## What the workflow does (in order)
+
+1. **Re-runs the validator** (ADR-0001) on the tagged tree.
+2. **Re-runs the plugin version check** (`npm run check`).
+3. **Re-runs `npm audit --audit-level=high`** (ADR-0012).
+4. **Asserts `marketplace.json#version` equals the tag** (minus `v`
+   prefix). Fails loudly if they diverge.
+5. **Generates `plugin-pins.json`** — derived
+   `{name, repo, ref, version}[]` for the audit lane.
+6. **Generates `sbom.cdx.json`** — CycloneDX 1.6 SBOM of the validator's
+   own supply chain (this repo's `package-lock.json`). Uses
+   `@cyclonedx/cyclonedx-npm`.
+7. **Extracts the matching `CHANGELOG.md` section** as release notes.
+8. **Creates a GitHub Release** named `v<X>.<Y>.<Z>` with the three
+   artifacts attached: `marketplace.json`, `plugin-pins.json`,
+   `sbom.cdx.json`.
+
+## After the workflow
+
+- **Verify the release:** `gh release view "v<X>.<Y>.<Z>"`. Confirm all
+  three artifacts are present and the release notes match the CHANGELOG
+  section.
+- **Tag protection is automatic** — ADR-0010's tag protection on `v*`
+  prevents rewrites and deletions once landed.
+- **Communicate** the release per your usual channels (PR thread, Slack,
+  etc.) if anyone is pinning to specific marketplace versions.
+
+## Common scenarios
+
+### "The workflow failed on `Assert manifest version matches tag`"
+
+You bumped the tag but not `marketplace.json#version` (or vice versa).
+The workflow output names the mismatch. Fix:
+
+1. Delete the local tag: `git tag -d v<X>.<Y>.<Z>`
+2. **Don't push-delete the remote tag** — tag protection blocks it,
+   and even if it didn't, deleting a published tag is anti-pattern.
+3. Open a fix-up PR bumping `marketplace.json#version` to match the
+   tag, OR pick the next available version number and re-tag.
+
+### "Renovate opened a PR right before I tagged"
+
+Merge the Renovate PR first if it's relevant to the release. Tagging
+catches the tip of `main` at tag time — any PR not merged is excluded.
+
+### "I need to cut a hotfix release"
+
+Same flow. Hotfixes are patches (`v0.3.0 → v0.3.1`). Don't release
+from a non-`main` branch unless you've set up a sustained release-branch
+model (currently not in scope).
+
+### "The SBOM generation step failed"
+
+Most likely cause: a transient `npx` download failure. Re-run the
+workflow from the GitHub Actions UI (re-run failed jobs). The tag
+push is the authoritative trigger; re-running the workflow does
+not require a new tag.
+
+### "I want to delete an accidental tag"
+
+You can't — tag protection blocks deletion. If a tag was pushed in
+error, the right response is:
+
+1. The (incorrect) release artifact stays in history; that's the
+   point of immutable releases.
+2. Cut a new tag with the correct version. Note in the release notes
+   what changed and why.
+3. If the bad release is materially harmful (e.g., contains a CVE
+   the world thinks is fixed), publish a security advisory referencing
+   it.
+
+## Why we don't use `workflow_dispatch` for releases
+
+Tags are the authoritative artifact identifier. Allowing manual
+dispatch would let a maintainer re-run the workflow against a
+different tag, which dilutes the "the tag IS the release intent"
+discipline. If a botched release ever needs re-publishing, fix-up via
+a new tag rather than re-running against the bad one.

--- a/scripts/extract-changelog.test.ts
+++ b/scripts/extract-changelog.test.ts
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { extractChangelogSection } from "./extract-changelog.js";
+
+const SAMPLE = `# Changelog
+
+Some intro text that should not be returned.
+
+## [Unreleased]
+
+### Added
+
+- A new thing.
+
+### Changed
+
+- A changed thing.
+
+## [0.2.0] - 2026-04-28
+
+Governance section.
+
+### Added
+
+- 0.2.0 added.
+
+## [0.1.0] - 2026-04-28
+
+### Added
+
+- 0.1.0 added.
+`;
+
+describe("extractChangelogSection", () => {
+  it("extracts the Unreleased section", () => {
+    const out = extractChangelogSection(SAMPLE, "Unreleased");
+    assert.match(out, /A new thing/);
+    assert.match(out, /A changed thing/);
+    // Should NOT include the next section's content
+    assert.doesNotMatch(out, /Governance section/);
+  });
+
+  it("extracts a versioned section by version string", () => {
+    const out = extractChangelogSection(SAMPLE, "0.2.0");
+    assert.match(out, /Governance section/);
+    assert.match(out, /0\.2\.0 added/);
+    // Should NOT include adjacent sections
+    assert.doesNotMatch(out, /A new thing/);
+    assert.doesNotMatch(out, /0\.1\.0 added/);
+  });
+
+  it("extracts the final section in the file", () => {
+    const out = extractChangelogSection(SAMPLE, "0.1.0");
+    assert.match(out, /0\.1\.0 added/);
+  });
+
+  it("throws on a missing section", () => {
+    assert.throws(
+      () => extractChangelogSection(SAMPLE, "9.9.9"),
+      /CHANGELOG section for \[9\.9\.9\] not found/,
+    );
+  });
+
+  it("escapes regex metacharacters in the version string", () => {
+    // A literal `.` in 0.2.0 should not also match `0X2Y0`. Construct a sample
+    // where a non-escaped version would accidentally match.
+    const tricky = `## [0X2Y0]\n\nshould NOT match.\n\n## [0.2.0]\n\nshould match.\n`;
+    const out = extractChangelogSection(tricky, "0.2.0");
+    assert.match(out, /should match/);
+    assert.doesNotMatch(out, /should NOT match/);
+  });
+});

--- a/scripts/extract-changelog.ts
+++ b/scripts/extract-changelog.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+// SPDX-License-Identifier: MPL-2.0
+
+// Extract a section of CHANGELOG.md for a given version. Used by the
+// release workflow to populate the GitHub Release body from the
+// matching CHANGELOG section.
+//
+// Usage:
+//   tsx scripts/extract-changelog.ts <version>
+//
+// Examples:
+//   tsx scripts/extract-changelog.ts 0.3.0
+//   tsx scripts/extract-changelog.ts Unreleased
+//
+// Exits 0 and prints the section body to stdout on success.
+// Exits 2 with a clear error if the section is missing.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function extractChangelogSection(changelog: string, version: string): string {
+  // Section headers look like:
+  //   ## [Unreleased]
+  //   ## [0.2.0] - 2026-04-28
+  // Find the requested header line, then collect everything until the next
+  // `## [` header line or end of file. Line-based scan avoids JS regex's
+  // lack of a "true end of string" anchor.
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const headerRegex = new RegExp(String.raw`^## \[${escaped}\]`);
+  const nextHeaderRegex = /^## \[/;
+
+  const lines = changelog.split("\n");
+
+  let startIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (headerRegex.test(lines[i])) {
+      startIdx = i;
+      break;
+    }
+  }
+  if (startIdx === -1) {
+    throw new Error(`CHANGELOG section for [${version}] not found`);
+  }
+
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (nextHeaderRegex.test(lines[i])) {
+      endIdx = i;
+      break;
+    }
+  }
+
+  return lines.slice(startIdx + 1, endIdx).join("\n").trim();
+}
+
+function main(): void {
+  const version = process.argv[2];
+  if (!version) {
+    console.error("usage: tsx scripts/extract-changelog.ts <version>");
+    process.exit(2);
+  }
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const root = resolve(__dirname, "..");
+  const changelog = readFileSync(resolve(root, "CHANGELOG.md"), "utf-8");
+  try {
+    const section = extractChangelogSection(changelog, version);
+    process.stdout.write(section + "\n");
+  } catch (err) {
+    console.error(`[ERROR] ${(err as Error).message}`);
+    process.exit(2);
+  }
+}
+
+const invoked =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (invoked) {
+  main();
+}


### PR DESCRIPTION
## Summary

Closes #77. Adds a tag-triggered release workflow that publishes a GitHub Release with three artifacts on every \`v*\` tag.

## Release artifacts

| Artifact | What it is |
| --- | --- |
| \`marketplace.json\` | Verbatim manifest snapshot at the tag |
| \`plugin-pins.json\` | Derived \`{name, repo, ref, version}[]\` — diffable between releases |
| \`sbom.cdx.json\` | CycloneDX 1.6 SBOM of the validator's own supply chain |

## Release model (ADR-0013)

- **Manual semver tag** at maintainer discretion
- **patch** — plugin patch/minor bumps only
- **minor** — new plugin/guidebook OR consumer-visible ADR
- **major** — breaking schema change OR plugin removal
- \`marketplace.json#version\` MUST equal the tag (workflow asserts)

## Workflow gates before publish

1. Re-run validator (ADR-0001)
2. Re-run plugin version check
3. Re-run \`npm audit --audit-level=high\` (ADR-0012)
4. Assert manifest version matches the tag
5. Generate plugin-pins.json + SBOM
6. Extract CHANGELOG section as release notes
7. Publish GitHub Release with artifacts attached

## Why release at all

Plugins are continuously updated by Renovate; the install lane (\`github>aida-core/aida-marketplace\` tracking main) doesn't need releases. The **audit lane** does — regulated downstream marketplaces and supply-chain reviewers want an immutable "what was the registry at moment X" artifact with diffable plugin pins + SBOM.

## Files

- \`.github/workflows/release.yml\` — tag-triggered workflow
- \`scripts/extract-changelog.ts\` — line-based CHANGELOG section parser
- \`scripts/extract-changelog.test.ts\` — 5 unit tests
- \`docs/adr/0013-marketplace-release-model.md\` — ADR
- \`docs/runbooks/release.md\` — operational runbook
- \`docs/adr/README.md\` — index updated
- \`CHANGELOG.md\` — entries

## Local verification

- \`npm test\` ✓ (67/67 — 5 new for extract-changelog)
- \`npm run typecheck\` ✓
- \`make lint-yaml\` ✓

## Test plan

- [ ] PR CI green
- [ ] Post-merge: cut a sandbox \`v0.0.0-test\` tag → workflow should fail the version-match gate (manifest is 0.2.0). Confirms the gate works. Delete tag (tag protection allows initial deletion before any history; or use a non-\`v\` tag to avoid protection)
- [ ] Real release: when ready, follow the runbook to cut \`v0.3.0\` after this PR + any pending changes are in

## Tag protection interaction

ADR-0010's tag protection on \`v*\` is already in place — release tags are immutable once published.