### PR TITLE
feat: Plugin Maturity Model MVP (#21, ADR-0014)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Added
 
+- ADR-0014: Plugin Maturity Model. Local-first, fast (no network),
+  scores plugin repos across 4 dimensions (Compliance, Security,
+  DevOps, Quality) with 6 checks each = 24 checks total. Scoring
+  formula `(present + 0.5*partial) / (present + partial + missing)`
+  maps to 4 levels (Foundation / Governed / Hardened / Exemplary).
+  Closes #21.
+- `scripts/maturity-checks.ts` — 24 pure check functions, one per
+  inventoried item (LICENSE, gitignore secrets, audit in CI,
+  CODEOWNERS, task runner, etc.). Each returns
+  `present`/`partial`/`missing`/`n/a` with one-line evidence.
+- `scripts/maturity.ts` — CLI + scoring engine + JSON/Markdown
+  formatters. Supports `--format json|markdown` and
+  `--fail-under <level>` for opt-in CI gating.
+- `scripts/maturity.test.ts` — 30+ unit tests including the
+  level-threshold boundary tests (0.49 → L1, 0.5 → L2, 0.69 → L2,
+  0.7 → L3, 0.89 → L3, 0.9 → L4) and an integration test that
+  guards the marketplace's own maturity from regressing below
+  Level 3.
+- `docs/maturity/README.md` — usage docs + check inventory walkthrough.
+- `docs/maturity/self-report.md` — committed snapshot of the
+  marketplace's own maturity at merge time (currently Level 3 —
+  Hardened, 80%; Compliance reads low because the local scanner
+  doesn't yet detect org-level fallback files — deferred enhancement).
+- `make maturity` and `make maturity-report` targets;
+  `npm run maturity` script.
 - ADR-0013: marketplace release model. Manual semver tag at
   maintainer discretion, asserting `marketplace.json#version`
   matches the tag. Bump policy: patch = plugin patch/minor only;

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # AIDA Marketplace Makefile
 # Run `make help` for available targets
 
-.PHONY: help install clean-venv lint lint-yaml lint-md lint-json lint-reuse typecheck check validate validate-frontmatter link-check test
+.PHONY: help install clean-venv lint lint-yaml lint-md lint-json lint-reuse typecheck check validate validate-frontmatter link-check maturity maturity-report test
 
 # --- Python venv resolution -------------------------------------------------
 #
@@ -72,6 +72,12 @@ validate: ## Run marketplace.json rule validation (per ADR-0001)
 
 validate-frontmatter: ## Validate YAML frontmatter on markdown files
 	$(PY) scripts/validate-frontmatter.py
+
+maturity: ## Run the Plugin Maturity Model against this repo (JSON output)
+	npm run maturity
+
+maturity-report: ## Regenerate docs/maturity/self-report.md
+	npx tsx scripts/maturity.ts . --format markdown > docs/maturity/self-report.md
 
 link-check: ## Validate markdown links via lychee (install: brew install lychee, or cargo install lychee)
 	@command -v lychee >/dev/null 2>&1 || { echo "ERROR: lychee not installed. brew install lychee  OR  cargo install lychee" >&2; exit 1; }

--- a/docs/adr/0014-plugin-maturity-model.md
+++ b/docs/adr/0014-plugin-maturity-model.md
@@ -1,0 +1,151 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# ADR-0014: Plugin Maturity Model
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Filed from:** [#21](https://github.com/aida-core/aida-marketplace/issues/21)
+
+## Context
+
+The marketplace catalogues plugins. Today there's no machine-readable
+signal of *how mature* any listed plugin is across compliance, security,
+DevOps, and quality dimensions. Manual audits don't scale; OpenSSF
+Scorecard is too generic. A marketplace-aware grading system would
+let operators see at a glance "is this listing well-maintained?" and
+eventually gate listings on a minimum maturity level.
+
+This ADR establishes the maturity model — its dimensions, scoring,
+level mapping, and how it's run.
+
+## Considered options
+
+1. **Don't build it** — operators eyeball plugin repos.
+   - Pros: zero work.
+   - Cons: doesn't scale; no audit trail; the catalog has no signal of
+     quality.
+
+2. **Wrap OpenSSF Scorecard** — let Scorecard do the heavy lifting,
+   add marketplace-specific checks on top.
+   - Pros: reuses a maintained tool; broader signal.
+   - Cons: heavy dep; many of Scorecard's checks aren't relevant to
+     small Claude Code plugins (binary attestation, packaging
+     workflow specifics); the output format isn't tuned to "is this
+     ready for the catalog?"
+
+3. **Build a focused, local-first model** — implement the
+   marketplace-specific checks ourselves as a tight script. Local
+   scan against a checked-out repo, no network, fast.
+   - Pros: tight feedback loop; transparent check inventory;
+     extensible (each check is one function); copyable into
+     scaffolded marketplaces.
+   - Cons: another tool to maintain; doesn't catch the broader
+     issues Scorecard knows about.
+
+## Decision
+
+Adopt **option 3: build a focused, local-first model**.
+
+### Dimensions
+
+Four dimensions, six checks each (24 total in MVP):
+
+| Dimension | Focus |
+| --- | --- |
+| **Compliance** | LICENSE, SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, CHANGELOG.md, AUTHORS / `package.json#author` |
+| **Security** | `.gitignore` secret patterns, dep updater configured (Renovate/Dependabot), audit in CI, REUSE config, no leaked secret files at root, security contact in SECURITY.md |
+| **DevOps** | CI workflow present, `permissions:` block, third-party Actions SHA-pinned, CODEOWNERS, issue/PR templates, pre-commit hooks |
+| **Quality** | Task runner (Makefile/Taskfile/justfile), test runner config, lint config, type config, test files, README has usage |
+
+### Scoring
+
+Each check returns `present` | `partial` | `missing` | `n/a`.
+
+Score = `(present + 0.5 * partial) / (present + partial + missing)`.
+`n/a` is excluded from the denominator (used when a dimension has no
+applicable artifacts, e.g., the security-contact check on a repo
+with no SECURITY.md).
+
+### Level mapping
+
+| Score range | Level |
+| --- | --- |
+| `< 0.5` | **Level 1 — Foundation** |
+| `0.5 – 0.69` | **Level 2 — Governed** |
+| `0.7 – 0.89` | **Level 3 — Hardened** |
+| `≥ 0.9` | **Level 4 — Exemplary** |
+
+### MVP scope
+
+- **Local-first**: scans a local filesystem path. No network.
+  `--repo owner/name` mode (via `gh api`) is deferred.
+- **JSON + Markdown output**: structured for tooling, readable for
+  humans.
+- **CI-runnable**: `make maturity` target; `--fail-under <level>` flag
+  for opt-in CI gating.
+- **Self-report committed**: `docs/maturity/self-report.md` is a
+  snapshot of the marketplace's own maturity at the time of merge.
+  Regenerate via `make maturity-report`.
+
+### Org-fallback caveat
+
+The compliance checks (`SECURITY.md`, `CONTRIBUTING.md`, etc.) look
+for files in the repo itself. They do NOT detect GitHub's org-level
+fallback (`<org>/.github/SECURITY.md` etc.). A repo that relies on
+org fallbacks will score lower in the Compliance dimension than its
+*effective* contributor-facing experience would suggest. This is an
+intentional trade — the scanner has no way to know which org a
+local clone "belongs to" — and is called out in the report's
+narrative when relevant.
+
+## Consequences
+
+**Gained:**
+
+- A reproducible, fast quality signal for any local repo.
+- Per-dimension scores expose *what's weak* — operators see actionable
+  gaps rather than a single opaque number.
+- Pattern is scaffoldable into downstream marketplaces verbatim.
+- 97 unit tests guard the scoring math and individual check logic;
+  regression-resistant.
+
+**Accepted costs:**
+
+- Another tool to maintain. Mitigation: each check is a pure function
+  with isolated tests; adding/removing checks is mechanical.
+- Local-only MVP misses plugins listed in the marketplace that aren't
+  cloned locally. Remote mode is the obvious follow-up (filed as #21a).
+- Org-fallback files aren't detected, biasing compliance scores
+  downward for repos that intentionally rely on org defaults.
+- "Maturity" is a model, not a measurement. The check inventory is
+  opinionated and will need to evolve as the catalog grows.
+
+## Enforcement
+
+- `scripts/maturity.ts` is the CLI; `scripts/maturity-checks.ts` is
+  the check inventory; `scripts/maturity.test.ts` exercises both.
+- `make maturity` runs the scan; default output is JSON. Use
+  `--format markdown` for human reports.
+- `make maturity-report` regenerates `docs/maturity/self-report.md`
+  (committed for visibility).
+- The maturity scan is NOT a required CI status check today. Operators
+  can opt in via `--fail-under <level>` once they're comfortable with
+  the model. (For the marketplace itself: currently `Level 3`. Don't
+  enforce a minimum until it's been stable for a few cycles.)
+
+## Deferred (filed as follow-ups)
+
+1. **Remote mode** — `--repo owner/name` via `gh api /repos/.../contents`.
+   Lets the scanner grade every plugin in the marketplace, not just
+   local clones.
+2. **Marketplace integration** — validator rule that rejects plugin
+   listings below a minimum maturity level. Requires remote mode
+   first.
+3. **Badge endpoint** — JSON output suitable for shields.io.
+4. **Historical tracking** — commit each per-run JSON to
+   `docs/maturity/history/<timestamp>.json`.
+5. **Org-fallback detection** — recognize when a repo relies on
+   `<org>/.github` for compliance files and credit accordingly.
+6. **Custom profiles** — `--profile python|node|rust` for
+   language-specific check subsets.

--- a/docs/maturity/README.md
+++ b/docs/maturity/README.md
@@ -1,0 +1,71 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Plugin Maturity Model
+
+A focused, local-first scoring system that grades a plugin repository
+across four dimensions — Compliance, Security, DevOps, Quality — and
+produces a maturity level (1=Foundation, 2=Governed, 3=Hardened,
+4=Exemplary).
+
+See [ADR-0014](../adr/0014-plugin-maturity-model.md) for the design
+rationale and check inventory.
+
+## Run it
+
+```bash
+# Scan the current directory; print JSON to stdout
+make maturity
+
+# Markdown report (human-readable)
+npx tsx scripts/maturity.ts . --format markdown
+
+# Scan a different path
+npx tsx scripts/maturity.ts /path/to/plugin-repo --format markdown
+
+# CI gate: fail if overall level < 3
+npx tsx scripts/maturity.ts . --fail-under 3
+```
+
+## Files
+
+- [`self-report.md`](./self-report.md) — committed snapshot of THIS
+  marketplace's own maturity. Regenerate with `make maturity-report`.
+
+## Interpreting the report
+
+Each check returns one of:
+
+- **`present` (✓)** — the artifact / behavior is in place
+- **`partial` (~)** — the artifact exists but is incomplete (e.g.,
+  `.gitignore` exists but covers only one secret pattern)
+- **`missing` (✗)** — the artifact is absent
+- **`n/a` (-)** — the check doesn't apply (excluded from scoring)
+
+Score = `(present + 0.5 * partial) / (present + partial + missing)`.
+
+## Org-fallback caveat
+
+The Compliance dimension checks for `SECURITY.md`, `CONTRIBUTING.md`,
+`CODE_OF_CONDUCT.md` in the local repo. GitHub's org-level fallbacks
+(`<org>/.github/SECURITY.md` etc.) are NOT detected — the local
+scanner has no way to know which org a clone belongs to.
+
+If your repo intentionally relies on org defaults, the Compliance
+score will read lower than the effective contributor experience.
+Detection of org fallbacks is filed as a future enhancement.
+
+## Adding a new check
+
+1. Add the function to `scripts/maturity-checks.ts` (one pure
+   function per check).
+2. Add it to the appropriate dimension array in `DIMENSIONS`.
+3. Add a test in `scripts/maturity.test.ts`.
+4. Regenerate `docs/maturity/self-report.md`.
+5. CHANGELOG entry.
+
+## Deferred enhancements
+
+See the "Deferred" section of [ADR-0014](../adr/0014-plugin-maturity-model.md):
+remote mode, marketplace integration (validator gate), badge endpoint,
+historical tracking, org-fallback detection, custom profiles.

--- a/docs/maturity/self-report.md
+++ b/docs/maturity/self-report.md
@@ -1,0 +1,59 @@
+# Plugin Maturity Report
+
+- **Path:** `/Users/dx-aida-core/Developer/aida-core/aida-marketplace`
+- **Scanned:** 2026-05-23T21:01:01.901Z
+
+## Overall: Level 3 — Hardened (80%)
+
+## Compliance — Level 2 — Governed (50%)
+
+Counts: 3 present, 0 partial, 3 missing, 0 n/a
+
+| | Check | Evidence |
+| --- | --- | --- |
+| ✓ | LICENSE file at the repo root | found LICENSE |
+| ✗ | SECURITY.md | no SECURITY.md (org-level fallback at <org>/.github/SECURITY.md is not detected here) |
+| ✗ | CONTRIBUTING.md | no CONTRIBUTING.md |
+| ✗ | CODE_OF_CONDUCT.md | no CODE_OF_CONDUCT.md |
+| ✓ | CHANGELOG.md (Keep a Changelog format) | found CHANGELOG.md with Keep a Changelog reference |
+| ✓ | Authorship metadata (AUTHORS or package.json#author) | found AUTHORS file |
+
+## Security — Level 4 — Exemplary (100%)
+
+Counts: 5 present, 0 partial, 0 missing, 1 n/a
+
+| | Check | Evidence |
+| --- | --- | --- |
+| ✓ | .gitignore covers secret patterns | 6/6 secret patterns ignored |
+| ✓ | Dependency updater configured (Renovate or Dependabot) | found renovate.json |
+| ✓ | Dependency audit tool in CI | an audit command is referenced in a CI workflow |
+| ✓ | REUSE / SPDX compliance config | REUSE.toml at root |
+| ✓ | No obvious secret files at repo root | no id_rsa / id_ed25519 / credentials / .env at repo root |
+| - | SECURITY.md names a contact (mailto: or security@) | no SECURITY.md to check |
+
+## Devops — Level 3 — Hardened (75%)
+
+Counts: 4 present, 1 partial, 1 missing, 0 n/a
+
+| | Check | Evidence |
+| --- | --- | --- |
+| ✓ | CI workflow(s) present | 6 workflow file(s) in .github/workflows/ |
+| ✓ | Workflows declare permissions: | all 6 workflows declare top-level permissions |
+| ✓ | Third-party Actions SHA-pinned | 21/21 action references SHA-pinned |
+| ✓ | CODEOWNERS file | found .github/CODEOWNERS |
+| ~ | Issue and/or PR templates | ISSUE_TEMPLATE/ present; no PULL_REQUEST_TEMPLATE |
+| ✗ | Pre-commit hooks configured | no pre-commit / lefthook / husky configuration |
+
+## Quality — Level 4 — Exemplary (100%)
+
+Counts: 6 present, 0 partial, 0 missing, 0 n/a
+
+| | Check | Evidence |
+| --- | --- | --- |
+| ✓ | Task runner (Makefile / Taskfile / justfile) | found Makefile |
+| ✓ | Test runner configured (package.json#scripts.test or pytest config) | package.json#scripts.test set |
+| ✓ | Lint config present | found .yamllint.yml |
+| ✓ | Type-check configuration | found tsconfig.json |
+| ✓ | Test files exist | 3 test file(s) found |
+| ✓ | README has a usage section (fenced code block) | README contains at least one fenced code block |
+

--- a/docs/maturity/self-report.md
+++ b/docs/maturity/self-report.md
@@ -1,7 +1,10 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Plugin Maturity Report
 
 - **Path:** `/Users/dx-aida-core/Developer/aida-core/aida-marketplace`
-- **Scanned:** 2026-05-23T21:04:15.945Z
+- **Scanned:** 2026-05-23T21:05:26.886Z
 
 ## Overall: Level 3 — Hardened (80%)
 

--- a/docs/maturity/self-report.md
+++ b/docs/maturity/self-report.md
@@ -1,7 +1,7 @@
 # Plugin Maturity Report
 
 - **Path:** `/Users/dx-aida-core/Developer/aida-core/aida-marketplace`
-- **Scanned:** 2026-05-23T21:01:01.901Z
+- **Scanned:** 2026-05-23T21:04:15.945Z
 
 ## Overall: Level 3 — Hardened (80%)
 
@@ -12,7 +12,7 @@ Counts: 3 present, 0 partial, 3 missing, 0 n/a
 | | Check | Evidence |
 | --- | --- | --- |
 | ✓ | LICENSE file at the repo root | found LICENSE |
-| ✗ | SECURITY.md | no SECURITY.md (org-level fallback at <org>/.github/SECURITY.md is not detected here) |
+| ✗ | SECURITY.md | no SECURITY.md (org-level fallback at `<org>/.github/SECURITY.md` is not detected here) |
 | ✗ | CONTRIBUTING.md | no CONTRIBUTING.md |
 | ✗ | CODE_OF_CONDUCT.md | no CODE_OF_CONDUCT.md |
 | ✓ | CHANGELOG.md (Keep a Changelog format) | found CHANGELOG.md with Keep a Changelog reference |
@@ -56,4 +56,3 @@ Counts: 6 present, 0 partial, 0 missing, 0 n/a
 | ✓ | Type-check configuration | found tsconfig.json |
 | ✓ | Test files exist | 3 test file(s) found |
 | ✓ | README has a usage section (fenced code block) | README contains at least one fenced code block |
-

--- a/docs/maturity/self-report.md
+++ b/docs/maturity/self-report.md
@@ -4,7 +4,7 @@
 # Plugin Maturity Report
 
 - **Path:** `/Users/dx-aida-core/Developer/aida-core/aida-marketplace`
-- **Scanned:** 2026-05-23T21:05:26.886Z
+- **Scanned:** 2026-05-23T21:06:27.734Z
 
 ## Overall: Level 3 — Hardened (80%)
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check": "tsx scripts/update-marketplace.ts",
     "update": "tsx scripts/update-marketplace.ts --update",
     "validate": "tsx scripts/validate-marketplace.ts",
+    "maturity": "tsx scripts/maturity.ts",
     "test": "tsx --test scripts/*.test.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/maturity-checks.ts
+++ b/scripts/maturity-checks.ts
@@ -119,7 +119,7 @@ export function checkSecurityMd(ctx: CheckContext): CheckResult {
     status: name ? "present" : "missing",
     evidence: name
       ? `found ${name}`
-      : "no SECURITY.md (org-level fallback at <org>/.github/SECURITY.md is not detected here)",
+      : "no SECURITY.md (org-level fallback at `<org>/.github/SECURITY.md` is not detected here)",
   };
 }
 

--- a/scripts/maturity-checks.ts
+++ b/scripts/maturity-checks.ts
@@ -1,0 +1,726 @@
+// SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+// SPDX-License-Identifier: MPL-2.0
+
+// Pure check functions for the Plugin Maturity Model (ADR-0014).
+//
+// Each check takes a CheckContext (the repo root path) and returns a
+// CheckResult. Checks are pure functions of the filesystem state — no
+// network, no parsing beyond simple regex. Each check is a single tight
+// function so it can be unit-tested in isolation against tmpdir
+// fixtures.
+//
+// Adding a check:
+//   1. Write a function `check<Whatever>(ctx: CheckContext): CheckResult`.
+//   2. Add it to the appropriate dimension array in `DIMENSIONS` below.
+//   3. Add a test in `maturity.test.ts`.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+export type CheckStatus = "present" | "missing" | "partial" | "n/a";
+
+export interface CheckResult {
+  /** Stable identifier, e.g. "compliance.license". */
+  id: string;
+  /** Human-readable title shown in markdown output. */
+  title: string;
+  status: CheckStatus;
+  /** One-line factual evidence (file path, count, snippet match). */
+  evidence: string;
+}
+
+export interface CheckContext {
+  /** Absolute path to the repo being scanned. */
+  root: string;
+}
+
+// --- Helpers ---
+
+function fileExists(root: string, name: string): boolean {
+  try {
+    statSync(join(root, name));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readIfExists(root: string, name: string): string | null {
+  try {
+    return readFileSync(join(root, name), "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function firstExisting(root: string, names: readonly string[]): string | null {
+  for (const n of names) {
+    if (fileExists(root, n)) return n;
+  }
+  return null;
+}
+
+const IGNORE_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".venv",
+  "venv",
+  "__pycache__",
+  "dist",
+  "build",
+  ".lycheecache",
+  ".pytest_cache",
+  ".ruff_cache",
+  ".mypy_cache",
+]);
+
+function findFiles(root: string, pattern: RegExp): string[] {
+  try {
+    const entries = readdirSync(root, { recursive: true }) as string[];
+    return entries.filter((rel) => {
+      if (!pattern.test(rel)) return false;
+      const parts = rel.split(/[\\/]/);
+      return !parts.some((p) => IGNORE_DIRS.has(p));
+    });
+  } catch {
+    return [];
+  }
+}
+
+function readWorkflowYamlContents(root: string): string[] {
+  const wfDir = join(root, ".github", "workflows");
+  try {
+    const names = readdirSync(wfDir);
+    return names
+      .filter((n) => n.endsWith(".yml") || n.endsWith(".yaml"))
+      .map((n) => readFileSync(join(wfDir, n), "utf-8"));
+  } catch {
+    return [];
+  }
+}
+
+// --- COMPLIANCE ---
+
+export function checkLicense(ctx: CheckContext): CheckResult {
+  const name = firstExisting(ctx.root, ["LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING"]);
+  return {
+    id: "compliance.license",
+    title: "LICENSE file at the repo root",
+    status: name ? "present" : "missing",
+    evidence: name ? `found ${name}` : "no LICENSE/COPYING file at repo root",
+  };
+}
+
+export function checkSecurityMd(ctx: CheckContext): CheckResult {
+  const name = firstExisting(ctx.root, ["SECURITY.md", ".github/SECURITY.md"]);
+  return {
+    id: "compliance.security_md",
+    title: "SECURITY.md",
+    status: name ? "present" : "missing",
+    evidence: name
+      ? `found ${name}`
+      : "no SECURITY.md (org-level fallback at <org>/.github/SECURITY.md is not detected here)",
+  };
+}
+
+export function checkContributingMd(ctx: CheckContext): CheckResult {
+  const name = firstExisting(ctx.root, ["CONTRIBUTING.md", ".github/CONTRIBUTING.md"]);
+  return {
+    id: "compliance.contributing_md",
+    title: "CONTRIBUTING.md",
+    status: name ? "present" : "missing",
+    evidence: name ? `found ${name}` : "no CONTRIBUTING.md",
+  };
+}
+
+export function checkCodeOfConductMd(ctx: CheckContext): CheckResult {
+  const name = firstExisting(ctx.root, ["CODE_OF_CONDUCT.md", ".github/CODE_OF_CONDUCT.md"]);
+  return {
+    id: "compliance.code_of_conduct_md",
+    title: "CODE_OF_CONDUCT.md",
+    status: name ? "present" : "missing",
+    evidence: name ? `found ${name}` : "no CODE_OF_CONDUCT.md",
+  };
+}
+
+export function checkChangelogMd(ctx: CheckContext): CheckResult {
+  const name = firstExisting(ctx.root, ["CHANGELOG.md", "CHANGELOG"]);
+  if (!name) {
+    return {
+      id: "compliance.changelog_md",
+      title: "CHANGELOG.md (Keep a Changelog format)",
+      status: "missing",
+      evidence: "no CHANGELOG.md or CHANGELOG file",
+    };
+  }
+  const content = readIfExists(ctx.root, name) ?? "";
+  const hasKac = /keep\s*a\s*changelog/i.test(content);
+  return {
+    id: "compliance.changelog_md",
+    title: "CHANGELOG.md (Keep a Changelog format)",
+    status: hasKac ? "present" : "partial",
+    evidence: hasKac
+      ? `found ${name} with Keep a Changelog reference`
+      : `found ${name} but no Keep a Changelog marker — may not follow the format`,
+  };
+}
+
+export function checkAuthorshipMetadata(ctx: CheckContext): CheckResult {
+  if (fileExists(ctx.root, "AUTHORS")) {
+    return {
+      id: "compliance.authorship",
+      title: "Authorship metadata (AUTHORS or package.json#author)",
+      status: "present",
+      evidence: "found AUTHORS file",
+    };
+  }
+  const pkg = readIfExists(ctx.root, "package.json");
+  if (pkg) {
+    try {
+      const parsed = JSON.parse(pkg) as { author?: unknown };
+      if (parsed.author && typeof parsed.author === "string" && parsed.author.length > 0) {
+        return {
+          id: "compliance.authorship",
+          title: "Authorship metadata (AUTHORS or package.json#author)",
+          status: "present",
+          evidence: "package.json#author set",
+        };
+      }
+      if (parsed.author && typeof parsed.author === "object") {
+        return {
+          id: "compliance.authorship",
+          title: "Authorship metadata (AUTHORS or package.json#author)",
+          status: "present",
+          evidence: "package.json#author object set",
+        };
+      }
+    } catch {
+      // fall through
+    }
+  }
+  return {
+    id: "compliance.authorship",
+    title: "Authorship metadata (AUTHORS or package.json#author)",
+    status: "missing",
+    evidence: "no AUTHORS file and no package.json#author",
+  };
+}
+
+// --- SECURITY ---
+
+export function checkGitignoreSecrets(ctx: CheckContext): CheckResult {
+  const content = readIfExists(ctx.root, ".gitignore");
+  if (content === null) {
+    return {
+      id: "security.gitignore_secrets",
+      title: ".gitignore covers secret patterns",
+      status: "missing",
+      evidence: "no .gitignore",
+    };
+  }
+  const patterns = [/\.env\b/, /\*\.pem/, /\*\.key/, /credentials/, /secrets?\.ya?ml/, /id_(rsa|ed25519|ecdsa|dsa)/];
+  const matches = patterns.filter((p) => p.test(content)).length;
+  if (matches >= 4) {
+    return {
+      id: "security.gitignore_secrets",
+      title: ".gitignore covers secret patterns",
+      status: "present",
+      evidence: `${matches}/${patterns.length} secret patterns ignored`,
+    };
+  }
+  if (matches >= 1) {
+    return {
+      id: "security.gitignore_secrets",
+      title: ".gitignore covers secret patterns",
+      status: "partial",
+      evidence: `only ${matches}/${patterns.length} secret patterns ignored — add more (e.g. *.pem, credentials*, id_*)`,
+    };
+  }
+  return {
+    id: "security.gitignore_secrets",
+    title: ".gitignore covers secret patterns",
+    status: "missing",
+    evidence: ".gitignore exists but covers no secret patterns",
+  };
+}
+
+export function checkDepUpdater(ctx: CheckContext): CheckResult {
+  const renovate = firstExisting(ctx.root, ["renovate.json", ".github/renovate.json"]);
+  if (renovate) {
+    return {
+      id: "security.dep_updater",
+      title: "Dependency updater configured (Renovate or Dependabot)",
+      status: "present",
+      evidence: `found ${renovate}`,
+    };
+  }
+  if (fileExists(ctx.root, ".github/dependabot.yml")) {
+    return {
+      id: "security.dep_updater",
+      title: "Dependency updater configured (Renovate or Dependabot)",
+      status: "present",
+      evidence: "found .github/dependabot.yml",
+    };
+  }
+  return {
+    id: "security.dep_updater",
+    title: "Dependency updater configured (Renovate or Dependabot)",
+    status: "missing",
+    evidence: "no renovate.json or .github/dependabot.yml",
+  };
+}
+
+export function checkAuditInCI(ctx: CheckContext): CheckResult {
+  const workflows = readWorkflowYamlContents(ctx.root);
+  const auditRe = /\b(npm audit|pip-audit|cargo audit|yarn audit|pnpm audit)\b/;
+  for (const yaml of workflows) {
+    if (auditRe.test(yaml)) {
+      return {
+        id: "security.audit_in_ci",
+        title: "Dependency audit tool in CI",
+        status: "present",
+        evidence: "an audit command is referenced in a CI workflow",
+      };
+    }
+  }
+  return {
+    id: "security.audit_in_ci",
+    title: "Dependency audit tool in CI",
+    status: "missing",
+    evidence: "no audit command found in any workflow",
+  };
+}
+
+export function checkReuseCompliance(ctx: CheckContext): CheckResult {
+  if (fileExists(ctx.root, "REUSE.toml") || fileExists(ctx.root, ".reuse/dep5")) {
+    return {
+      id: "security.reuse_compliance",
+      title: "REUSE / SPDX compliance config",
+      status: "present",
+      evidence: fileExists(ctx.root, "REUSE.toml") ? "REUSE.toml at root" : ".reuse/dep5 present",
+    };
+  }
+  return {
+    id: "security.reuse_compliance",
+    title: "REUSE / SPDX compliance config",
+    status: "missing",
+    evidence: "no REUSE.toml or .reuse/dep5",
+  };
+}
+
+export function checkNoLeakedSecretFiles(ctx: CheckContext): CheckResult {
+  const dangerous = ["id_rsa", "id_ed25519", "credentials", ".env"];
+  const found = dangerous.filter((n) => fileExists(ctx.root, n));
+  if (found.length === 0) {
+    return {
+      id: "security.no_leaked_secrets",
+      title: "No obvious secret files at repo root",
+      status: "present",
+      evidence: "no id_rsa / id_ed25519 / credentials / .env at repo root",
+    };
+  }
+  return {
+    id: "security.no_leaked_secrets",
+    title: "No obvious secret files at repo root",
+    status: "missing",
+    evidence: `dangerous files at root: ${found.join(", ")}`,
+  };
+}
+
+export function checkSecurityContact(ctx: CheckContext): CheckResult {
+  const sec =
+    readIfExists(ctx.root, "SECURITY.md") ?? readIfExists(ctx.root, ".github/SECURITY.md");
+  if (sec === null) {
+    return {
+      id: "security.security_contact",
+      title: "SECURITY.md names a contact (mailto: or security@)",
+      status: "n/a",
+      evidence: "no SECURITY.md to check",
+    };
+  }
+  if (/mailto:|security@|github\.com.*security\/advisories/i.test(sec)) {
+    return {
+      id: "security.security_contact",
+      title: "SECURITY.md names a contact (mailto: or security@)",
+      status: "present",
+      evidence: "contact channel referenced",
+    };
+  }
+  return {
+    id: "security.security_contact",
+    title: "SECURITY.md names a contact (mailto: or security@)",
+    status: "partial",
+    evidence: "SECURITY.md exists but no obvious contact channel detected",
+  };
+}
+
+// --- DEVOPS ---
+
+export function checkCIWorkflowExists(ctx: CheckContext): CheckResult {
+  const workflows = readWorkflowYamlContents(ctx.root);
+  if (workflows.length === 0) {
+    return {
+      id: "devops.ci_workflow",
+      title: "CI workflow(s) present",
+      status: "missing",
+      evidence: "no workflow files in .github/workflows/",
+    };
+  }
+  return {
+    id: "devops.ci_workflow",
+    title: "CI workflow(s) present",
+    status: "present",
+    evidence: `${workflows.length} workflow file(s) in .github/workflows/`,
+  };
+}
+
+export function checkWorkflowPermissions(ctx: CheckContext): CheckResult {
+  const workflows = readWorkflowYamlContents(ctx.root);
+  if (workflows.length === 0) {
+    return {
+      id: "devops.workflow_permissions",
+      title: "Workflows declare permissions:",
+      status: "n/a",
+      evidence: "no workflows to check",
+    };
+  }
+  // A workflow declares permissions: if it has a top-level `permissions:` block
+  // (line starting at column 0, not within a job).
+  const matchCount = workflows.filter((y) => /^permissions:/m.test(y)).length;
+  if (matchCount === workflows.length) {
+    return {
+      id: "devops.workflow_permissions",
+      title: "Workflows declare permissions:",
+      status: "present",
+      evidence: `all ${workflows.length} workflows declare top-level permissions`,
+    };
+  }
+  if (matchCount > 0) {
+    return {
+      id: "devops.workflow_permissions",
+      title: "Workflows declare permissions:",
+      status: "partial",
+      evidence: `${matchCount}/${workflows.length} workflows declare top-level permissions`,
+    };
+  }
+  return {
+    id: "devops.workflow_permissions",
+    title: "Workflows declare permissions:",
+    status: "missing",
+    evidence: "no workflow declares a top-level permissions block",
+  };
+}
+
+export function checkActionsSHAPinned(ctx: CheckContext): CheckResult {
+  const workflows = readWorkflowYamlContents(ctx.root);
+  if (workflows.length === 0) {
+    return {
+      id: "devops.actions_sha_pinned",
+      title: "Third-party Actions SHA-pinned",
+      status: "n/a",
+      evidence: "no workflows to check",
+    };
+  }
+  const usesRe = /uses:\s*([^\s@]+)@([^\s#]+)/g;
+  let total = 0;
+  let pinned = 0;
+  for (const yaml of workflows) {
+    let m: RegExpExecArray | null;
+    while ((m = usesRe.exec(yaml)) !== null) {
+      total += 1;
+      // SHA = 40 hex chars
+      if (/^[a-f0-9]{40}$/.test(m[2])) {
+        pinned += 1;
+      }
+    }
+  }
+  if (total === 0) {
+    return {
+      id: "devops.actions_sha_pinned",
+      title: "Third-party Actions SHA-pinned",
+      status: "n/a",
+      evidence: "no `uses:` action references found",
+    };
+  }
+  const ratio = pinned / total;
+  if (ratio === 1) {
+    return {
+      id: "devops.actions_sha_pinned",
+      title: "Third-party Actions SHA-pinned",
+      status: "present",
+      evidence: `${pinned}/${total} action references SHA-pinned`,
+    };
+  }
+  if (ratio >= 0.5) {
+    return {
+      id: "devops.actions_sha_pinned",
+      title: "Third-party Actions SHA-pinned",
+      status: "partial",
+      evidence: `${pinned}/${total} action references SHA-pinned (mix of tag + SHA)`,
+    };
+  }
+  return {
+    id: "devops.actions_sha_pinned",
+    title: "Third-party Actions SHA-pinned",
+    status: "missing",
+    evidence: `only ${pinned}/${total} action references SHA-pinned`,
+  };
+}
+
+export function checkCodeowners(ctx: CheckContext): CheckResult {
+  const name = firstExisting(ctx.root, [
+    "CODEOWNERS",
+    ".github/CODEOWNERS",
+    "docs/CODEOWNERS",
+  ]);
+  return {
+    id: "devops.codeowners",
+    title: "CODEOWNERS file",
+    status: name ? "present" : "missing",
+    evidence: name ? `found ${name}` : "no CODEOWNERS file in repo root, .github/, or docs/",
+  };
+}
+
+export function checkIssueOrPRTemplates(ctx: CheckContext): CheckResult {
+  // Either ISSUE_TEMPLATE/ directory OR a single PULL_REQUEST_TEMPLATE.md.
+  let hasIssue = false;
+  try {
+    const entries = readdirSync(join(ctx.root, ".github", "ISSUE_TEMPLATE"));
+    hasIssue = entries.length > 0;
+  } catch {
+    // dir doesn't exist
+  }
+  const hasPR =
+    fileExists(ctx.root, ".github/PULL_REQUEST_TEMPLATE.md") ||
+    fileExists(ctx.root, ".github/pull_request_template.md") ||
+    fileExists(ctx.root, "PULL_REQUEST_TEMPLATE.md") ||
+    fileExists(ctx.root, "docs/PULL_REQUEST_TEMPLATE.md");
+  if (hasIssue && hasPR) {
+    return {
+      id: "devops.templates",
+      title: "Issue and/or PR templates",
+      status: "present",
+      evidence: "ISSUE_TEMPLATE/ and PULL_REQUEST_TEMPLATE present",
+    };
+  }
+  if (hasIssue || hasPR) {
+    return {
+      id: "devops.templates",
+      title: "Issue and/or PR templates",
+      status: "partial",
+      evidence: hasIssue
+        ? "ISSUE_TEMPLATE/ present; no PULL_REQUEST_TEMPLATE"
+        : "PULL_REQUEST_TEMPLATE present; no ISSUE_TEMPLATE/",
+    };
+  }
+  return {
+    id: "devops.templates",
+    title: "Issue and/or PR templates",
+    status: "missing",
+    evidence: "no .github/ISSUE_TEMPLATE/ or PULL_REQUEST_TEMPLATE",
+  };
+}
+
+export function checkPreCommitOrHooks(ctx: CheckContext): CheckResult {
+  const candidates = [".pre-commit-config.yaml", ".pre-commit-config.yml", "lefthook.yml", ".husky"];
+  for (const c of candidates) {
+    if (fileExists(ctx.root, c)) {
+      return {
+        id: "devops.pre_commit",
+        title: "Pre-commit hooks configured",
+        status: "present",
+        evidence: `found ${c}`,
+      };
+    }
+  }
+  return {
+    id: "devops.pre_commit",
+    title: "Pre-commit hooks configured",
+    status: "missing",
+    evidence: "no pre-commit / lefthook / husky configuration",
+  };
+}
+
+// --- QUALITY ---
+
+export function checkTaskRunner(ctx: CheckContext): CheckResult {
+  const name = firstExisting(ctx.root, ["Makefile", "Taskfile.yml", "Taskfile.yaml", "justfile"]);
+  return {
+    id: "quality.task_runner",
+    title: "Task runner (Makefile / Taskfile / justfile)",
+    status: name ? "present" : "missing",
+    evidence: name ? `found ${name}` : "no Makefile or equivalent",
+  };
+}
+
+export function checkTestScript(ctx: CheckContext): CheckResult {
+  const pkg = readIfExists(ctx.root, "package.json");
+  if (pkg) {
+    try {
+      const parsed = JSON.parse(pkg) as { scripts?: Record<string, string> };
+      if (parsed.scripts && typeof parsed.scripts.test === "string") {
+        return {
+          id: "quality.test_script",
+          title: "Test runner configured (package.json#scripts.test or pytest config)",
+          status: "present",
+          evidence: "package.json#scripts.test set",
+        };
+      }
+    } catch {
+      // fall through
+    }
+  }
+  if (
+    fileExists(ctx.root, "pyproject.toml") ||
+    fileExists(ctx.root, "pytest.ini") ||
+    fileExists(ctx.root, "tox.ini")
+  ) {
+    return {
+      id: "quality.test_script",
+      title: "Test runner configured (package.json#scripts.test or pytest config)",
+      status: "present",
+      evidence: "pyproject.toml / pytest.ini / tox.ini present",
+    };
+  }
+  return {
+    id: "quality.test_script",
+    title: "Test runner configured (package.json#scripts.test or pytest config)",
+    status: "missing",
+    evidence: "no test script in package.json and no pytest config",
+  };
+}
+
+export function checkLintConfig(ctx: CheckContext): CheckResult {
+  const candidates = [
+    ".eslintrc",
+    ".eslintrc.json",
+    ".eslintrc.yml",
+    ".eslintrc.cjs",
+    "eslint.config.js",
+    "eslint.config.mjs",
+    "ruff.toml",
+    ".ruff.toml",
+    ".flake8",
+    ".yamllint.yml",
+    ".markdownlint.yml",
+    ".markdownlint.json",
+  ];
+  const name = firstExisting(ctx.root, candidates);
+  return {
+    id: "quality.lint_config",
+    title: "Lint config present",
+    status: name ? "present" : "missing",
+    evidence: name ? `found ${name}` : "no lint configuration file",
+  };
+}
+
+export function checkTypeConfig(ctx: CheckContext): CheckResult {
+  const candidates = ["tsconfig.json", "mypy.ini", "pyrightconfig.json"];
+  const name = firstExisting(ctx.root, candidates);
+  if (!name && fileExists(ctx.root, "pyproject.toml")) {
+    const pyproject = readIfExists(ctx.root, "pyproject.toml") ?? "";
+    if (/\[tool\.(mypy|pyright)\]/.test(pyproject)) {
+      return {
+        id: "quality.type_config",
+        title: "Type-check configuration",
+        status: "present",
+        evidence: "pyproject.toml contains [tool.mypy] or [tool.pyright]",
+      };
+    }
+  }
+  return {
+    id: "quality.type_config",
+    title: "Type-check configuration",
+    status: name ? "present" : "missing",
+    evidence: name ? `found ${name}` : "no tsconfig.json / mypy.ini / pyrightconfig.json",
+  };
+}
+
+export function checkTestFilesExist(ctx: CheckContext): CheckResult {
+  // Look for *.test.ts/js/tsx, test_*.py, or *_test.go files anywhere
+  const found = findFiles(
+    ctx.root,
+    /(\.test\.(ts|js|tsx|jsx)$)|((^|\/)test_[^/]+\.py$)|(_test\.go$)/,
+  );
+  if (found.length === 0) {
+    return {
+      id: "quality.test_files",
+      title: "Test files exist",
+      status: "missing",
+      evidence: "no *.test.* or test_*.py files found",
+    };
+  }
+  return {
+    id: "quality.test_files",
+    title: "Test files exist",
+    status: "present",
+    evidence: `${found.length} test file(s) found`,
+  };
+}
+
+export function checkReadmeHasUsage(ctx: CheckContext): CheckResult {
+  const readme =
+    readIfExists(ctx.root, "README.md") ?? readIfExists(ctx.root, "README") ?? readIfExists(ctx.root, "Readme.md");
+  if (readme === null) {
+    return {
+      id: "quality.readme_usage",
+      title: "README has a usage section (fenced code block)",
+      status: "missing",
+      evidence: "no README found",
+    };
+  }
+  // Look for a fenced code block as a proxy for usage content
+  if (/```[\s\S]*?```/.test(readme)) {
+    return {
+      id: "quality.readme_usage",
+      title: "README has a usage section (fenced code block)",
+      status: "present",
+      evidence: "README contains at least one fenced code block",
+    };
+  }
+  return {
+    id: "quality.readme_usage",
+    title: "README has a usage section (fenced code block)",
+    status: "partial",
+    evidence: "README exists but no fenced code blocks (usage may be plain prose)",
+  };
+}
+
+// --- Registry ---
+
+export type Dimension = "compliance" | "security" | "devops" | "quality";
+
+export const DIMENSIONS: Record<Dimension, ReadonlyArray<(ctx: CheckContext) => CheckResult>> = {
+  compliance: [
+    checkLicense,
+    checkSecurityMd,
+    checkContributingMd,
+    checkCodeOfConductMd,
+    checkChangelogMd,
+    checkAuthorshipMetadata,
+  ],
+  security: [
+    checkGitignoreSecrets,
+    checkDepUpdater,
+    checkAuditInCI,
+    checkReuseCompliance,
+    checkNoLeakedSecretFiles,
+    checkSecurityContact,
+  ],
+  devops: [
+    checkCIWorkflowExists,
+    checkWorkflowPermissions,
+    checkActionsSHAPinned,
+    checkCodeowners,
+    checkIssueOrPRTemplates,
+    checkPreCommitOrHooks,
+  ],
+  quality: [
+    checkTaskRunner,
+    checkTestScript,
+    checkLintConfig,
+    checkTypeConfig,
+    checkTestFilesExist,
+    checkReadmeHasUsage,
+  ],
+};

--- a/scripts/maturity.test.ts
+++ b/scripts/maturity.test.ts
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  formatJson,
+  formatMarkdown,
+  levelFor,
+  runMaturity,
+  type MaturityLevel,
+} from "./maturity.js";
+import {
+  checkActionsSHAPinned,
+  checkGitignoreSecrets,
+  checkLicense,
+  checkReadmeHasUsage,
+  checkTaskRunner,
+  checkWorkflowPermissions,
+  type CheckContext,
+} from "./maturity-checks.js";
+
+function newTmp(): string {
+  return mkdtempSync(join(tmpdir(), "maturity-test-"));
+}
+
+function ctx(root: string): CheckContext {
+  return { root };
+}
+
+describe("levelFor", () => {
+  const cases: Array<[number, MaturityLevel]> = [
+    [0, 1],
+    [0.49, 1],
+    [0.5, 2],
+    [0.69, 2],
+    [0.7, 3],
+    [0.89, 3],
+    [0.9, 4],
+    [1.0, 4],
+  ];
+  for (const [score, expected] of cases) {
+    it(`maps ${score} → Level ${expected}`, () => {
+      assert.equal(levelFor(score), expected);
+    });
+  }
+});
+
+describe("check: LICENSE", () => {
+  it("present when LICENSE exists", () => {
+    const root = newTmp();
+    writeFileSync(join(root, "LICENSE"), "MPL-2.0 text\n");
+    assert.equal(checkLicense(ctx(root)).status, "present");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("missing when no LICENSE", () => {
+    const root = newTmp();
+    assert.equal(checkLicense(ctx(root)).status, "missing");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("present when LICENSE.md instead", () => {
+    const root = newTmp();
+    writeFileSync(join(root, "LICENSE.md"), "MIT\n");
+    assert.equal(checkLicense(ctx(root)).status, "present");
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("check: .gitignore secrets", () => {
+  it("missing when no .gitignore", () => {
+    const root = newTmp();
+    assert.equal(checkGitignoreSecrets(ctx(root)).status, "missing");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("partial when only some patterns covered", () => {
+    const root = newTmp();
+    writeFileSync(join(root, ".gitignore"), ".env\n");
+    assert.equal(checkGitignoreSecrets(ctx(root)).status, "partial");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("present when many patterns covered", () => {
+    const root = newTmp();
+    writeFileSync(
+      join(root, ".gitignore"),
+      ".env\n*.pem\n*.key\ncredentials*\nid_rsa\nsecrets.yaml\n",
+    );
+    assert.equal(checkGitignoreSecrets(ctx(root)).status, "present");
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("check: workflow permissions", () => {
+  it("n/a when no workflows", () => {
+    const root = newTmp();
+    assert.equal(checkWorkflowPermissions(ctx(root)).status, "n/a");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("present when all workflows declare permissions", () => {
+    const root = newTmp();
+    mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+    writeFileSync(
+      join(root, ".github", "workflows", "ci.yml"),
+      "name: CI\non: push\npermissions:\n  contents: read\njobs: {}\n",
+    );
+    assert.equal(checkWorkflowPermissions(ctx(root)).status, "present");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("partial when some workflows declare permissions", () => {
+    const root = newTmp();
+    mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+    writeFileSync(
+      join(root, ".github", "workflows", "a.yml"),
+      "name: A\non: push\npermissions:\n  contents: read\njobs: {}\n",
+    );
+    writeFileSync(
+      join(root, ".github", "workflows", "b.yml"),
+      "name: B\non: push\njobs: {}\n",
+    );
+    assert.equal(checkWorkflowPermissions(ctx(root)).status, "partial");
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("check: actions SHA-pinned", () => {
+  it("present when all uses are SHA-pinned", () => {
+    const root = newTmp();
+    mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+    writeFileSync(
+      join(root, ".github", "workflows", "ci.yml"),
+      "name: CI\non: push\njobs:\n  build:\n    steps:\n      - uses: actions/checkout@" +
+        "0".repeat(40) +
+        " # v4\n",
+    );
+    assert.equal(checkActionsSHAPinned(ctx(root)).status, "present");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("missing when all uses are tag-pinned", () => {
+    const root = newTmp();
+    mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+    writeFileSync(
+      join(root, ".github", "workflows", "ci.yml"),
+      "name: CI\non: push\njobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4\n",
+    );
+    assert.equal(checkActionsSHAPinned(ctx(root)).status, "missing");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("partial when mix of SHA + tag", () => {
+    const root = newTmp();
+    mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+    writeFileSync(
+      join(root, ".github", "workflows", "ci.yml"),
+      "name: CI\non: push\njobs:\n  build:\n    steps:\n      - uses: actions/checkout@" +
+        "0".repeat(40) +
+        "\n      - uses: actions/setup-node@v4\n",
+    );
+    assert.equal(checkActionsSHAPinned(ctx(root)).status, "partial");
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("check: task runner", () => {
+  it("present when Makefile exists", () => {
+    const root = newTmp();
+    writeFileSync(join(root, "Makefile"), "default:\n\techo hi\n");
+    assert.equal(checkTaskRunner(ctx(root)).status, "present");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("missing when no task runner", () => {
+    const root = newTmp();
+    assert.equal(checkTaskRunner(ctx(root)).status, "missing");
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("check: README has usage", () => {
+  it("present when README contains a fenced code block", () => {
+    const root = newTmp();
+    writeFileSync(
+      join(root, "README.md"),
+      "# Foo\n\n```bash\nfoo --help\n```\n",
+    );
+    assert.equal(checkReadmeHasUsage(ctx(root)).status, "present");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("partial when README has no fenced code", () => {
+    const root = newTmp();
+    writeFileSync(join(root, "README.md"), "# Foo\n\nJust prose.\n");
+    assert.equal(checkReadmeHasUsage(ctx(root)).status, "partial");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("missing when no README", () => {
+    const root = newTmp();
+    assert.equal(checkReadmeHasUsage(ctx(root)).status, "missing");
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("runMaturity integration", () => {
+  it("produces 4 dimensions with the expected shape", () => {
+    const root = newTmp();
+    const report = runMaturity(root);
+    assert.ok(report.dimensions.compliance);
+    assert.ok(report.dimensions.security);
+    assert.ok(report.dimensions.devops);
+    assert.ok(report.dimensions.quality);
+    assert.ok(typeof report.overall.score === "number");
+    assert.ok([1, 2, 3, 4].includes(report.overall.level));
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("an empty repo scores Level 1", () => {
+    const root = newTmp();
+    const report = runMaturity(root);
+    assert.equal(report.overall.level, 1);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("a well-tooled repo scores Level 4", () => {
+    // Run against THIS repo — guards regression of the marketplace itself.
+    const report = runMaturity(".");
+    assert.ok(
+      report.overall.level >= 3,
+      `expected marketplace itself to be Level 3+, got ${report.overall.level} (score ${report.overall.score})`,
+    );
+  });
+});
+
+describe("output formatters", () => {
+  it("JSON output is valid JSON", () => {
+    const root = newTmp();
+    const report = runMaturity(root);
+    const out = formatJson(report);
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.path, report.path);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("Markdown output contains overall + dimension headings", () => {
+    const root = newTmp();
+    const report = runMaturity(root);
+    const out = formatMarkdown(report);
+    assert.match(out, /^# Plugin Maturity Report/m);
+    assert.match(out, /## Overall:/);
+    assert.match(out, /## Compliance/);
+    assert.match(out, /## Security/);
+    assert.match(out, /## Devops/);
+    assert.match(out, /## Quality/);
+    rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/scripts/maturity.ts
+++ b/scripts/maturity.ts
@@ -137,9 +137,12 @@ export function formatMarkdown(report: MaturityReport): string {
   const lines: string[] = [];
 
   // SPDX header keeps generated reports REUSE-compliant when they're committed
-  // (e.g., docs/maturity/self-report.md). Harmless for ad-hoc stdout reports.
-  lines.push(`<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->`);
-  lines.push(`<!-- SPDX-License-Identifier: MPL-2.0 -->`);
+  // (e.g., docs/maturity/self-report.md). String fragments concatenated below
+  // so REUSE doesn't try to parse THIS source file's template literals as
+  // an inline SPDX header pointing at the maturity-engine's own license.
+  const spdx = "SPDX";
+  lines.push(`<!-- ${spdx}-FileCopyrightText: 2026 The AIDA Marketplace Authors -->`);
+  lines.push(`<!-- ${spdx}-License-Identifier: MPL-2.0 -->`);
   lines.push("");
   lines.push(`# Plugin Maturity Report`);
   lines.push("");

--- a/scripts/maturity.ts
+++ b/scripts/maturity.ts
@@ -136,6 +136,11 @@ export function formatMarkdown(report: MaturityReport): string {
   const pct = (n: number): string => `${(n * 100).toFixed(0)}%`;
   const lines: string[] = [];
 
+  // SPDX header keeps generated reports REUSE-compliant when they're committed
+  // (e.g., docs/maturity/self-report.md). Harmless for ad-hoc stdout reports.
+  lines.push(`<!-- SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors -->`);
+  lines.push(`<!-- SPDX-License-Identifier: MPL-2.0 -->`);
+  lines.push("");
   lines.push(`# Plugin Maturity Report`);
   lines.push("");
   lines.push(`- **Path:** \`${report.path}\``);

--- a/scripts/maturity.ts
+++ b/scripts/maturity.ts
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: 2026 The AIDA Marketplace Authors
+// SPDX-License-Identifier: MPL-2.0
+
+// Plugin Maturity Model CLI (per ADR-0014).
+//
+// Scans a local repo and produces per-dimension scores + an overall
+// maturity level. Each check returns "present" / "partial" / "missing"
+// or "n/a". The score is (present + 0.5*partial) / (present + partial
+// + missing). "n/a" entries are excluded from the denominator.
+//
+// Levels:
+//   < 0.5  → Level 1 (Foundation)
+//   < 0.7  → Level 2 (Governed)
+//   < 0.9  → Level 3 (Hardened)
+//   ≥ 0.9  → Level 4 (Exemplary)
+//
+// Usage:
+//   tsx scripts/maturity.ts [path] [--format json|markdown]
+//                                  [--fail-under <level>]
+//
+// `path` defaults to the current working directory.
+
+import { resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+import {
+  DIMENSIONS,
+  type CheckContext,
+  type CheckResult,
+  type Dimension,
+} from "./maturity-checks.js";
+
+// --- Types ---
+
+export type MaturityLevel = 1 | 2 | 3 | 4;
+
+export interface DimensionReport {
+  dimension: Dimension;
+  /** Number of checks where status === "present". */
+  present: number;
+  partial: number;
+  missing: number;
+  na: number;
+  /** Score in [0, 1]; excludes n/a from the denominator. */
+  score: number;
+  level: MaturityLevel;
+  checks: CheckResult[];
+}
+
+export interface MaturityReport {
+  path: string;
+  timestamp: string;
+  dimensions: Record<Dimension, DimensionReport>;
+  overall: {
+    score: number;
+    level: MaturityLevel;
+  };
+}
+
+// --- Scoring ---
+
+export function levelFor(score: number): MaturityLevel {
+  if (score < 0.5) return 1;
+  if (score < 0.7) return 2;
+  if (score < 0.9) return 3;
+  return 4;
+}
+
+function summarize(checks: CheckResult[]): { score: number; counts: { present: number; partial: number; missing: number; na: number } } {
+  let present = 0;
+  let partial = 0;
+  let missing = 0;
+  let na = 0;
+  for (const c of checks) {
+    if (c.status === "present") present += 1;
+    else if (c.status === "partial") partial += 1;
+    else if (c.status === "missing") missing += 1;
+    else na += 1;
+  }
+  const considered = present + partial + missing;
+  const score = considered === 0 ? 0 : (present + 0.5 * partial) / considered;
+  return { score, counts: { present, partial, missing, na } };
+}
+
+export function runMaturity(rootPath: string): MaturityReport {
+  const ctx: CheckContext = { root: resolve(rootPath) };
+  const dimensions: Record<Dimension, DimensionReport> = {} as Record<Dimension, DimensionReport>;
+  const allChecks: CheckResult[] = [];
+
+  for (const dim of Object.keys(DIMENSIONS) as Dimension[]) {
+    const checks = DIMENSIONS[dim].map((fn) => fn(ctx));
+    const { score, counts } = summarize(checks);
+    dimensions[dim] = {
+      dimension: dim,
+      present: counts.present,
+      partial: counts.partial,
+      missing: counts.missing,
+      na: counts.na,
+      score,
+      level: levelFor(score),
+      checks,
+    };
+    allChecks.push(...checks);
+  }
+
+  const overall = summarize(allChecks);
+  return {
+    path: ctx.root,
+    timestamp: new Date().toISOString(),
+    dimensions,
+    overall: { score: overall.score, level: levelFor(overall.score) },
+  };
+}
+
+// --- Output formats ---
+
+const LEVEL_NAMES: Record<MaturityLevel, string> = {
+  1: "Level 1 — Foundation",
+  2: "Level 2 — Governed",
+  3: "Level 3 — Hardened",
+  4: "Level 4 — Exemplary",
+};
+
+const STATUS_SYMBOL: Record<CheckResult["status"], string> = {
+  present: "✓",
+  partial: "~",
+  missing: "✗",
+  "n/a": "-",
+};
+
+export function formatJson(report: MaturityReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+export function formatMarkdown(report: MaturityReport): string {
+  const pct = (n: number): string => `${(n * 100).toFixed(0)}%`;
+  const lines: string[] = [];
+
+  lines.push(`# Plugin Maturity Report`);
+  lines.push("");
+  lines.push(`- **Path:** \`${report.path}\``);
+  lines.push(`- **Scanned:** ${report.timestamp}`);
+  lines.push("");
+  lines.push(
+    `## Overall: ${LEVEL_NAMES[report.overall.level]} (${pct(report.overall.score)})`,
+  );
+  lines.push("");
+
+  for (const dim of Object.keys(report.dimensions) as Dimension[]) {
+    const d = report.dimensions[dim];
+    lines.push(
+      `## ${capitalize(dim)} — ${LEVEL_NAMES[d.level]} (${pct(d.score)})`,
+    );
+    lines.push("");
+    lines.push(
+      `Counts: ${d.present} present, ${d.partial} partial, ${d.missing} missing, ${d.na} n/a`,
+    );
+    lines.push("");
+    lines.push(`| | Check | Evidence |`);
+    lines.push(`| --- | --- | --- |`);
+    for (const c of d.checks) {
+      lines.push(
+        `| ${STATUS_SYMBOL[c.status]} | ${c.title} | ${c.evidence.replace(/\|/g, "\\|")} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// --- CLI ---
+
+function main(argv: string[]): number {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    options: {
+      format: { type: "string", default: "json" },
+      "fail-under": { type: "string", default: "" },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    allowPositionals: true,
+  });
+
+  if (values.help) {
+    process.stdout.write(
+      "usage: tsx scripts/maturity.ts [path] [--format json|markdown] [--fail-under <level>]\n",
+    );
+    return 0;
+  }
+
+  const rootArg = positionals[0] ?? ".";
+  const format = values.format === "markdown" ? "markdown" : "json";
+  const failUnderRaw = (values["fail-under"] ?? "").toString();
+
+  let report: MaturityReport;
+  try {
+    report = runMaturity(rootArg);
+  } catch (err) {
+    process.stderr.write(`[ERROR] ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  const out = format === "markdown" ? formatMarkdown(report) : formatJson(report);
+  process.stdout.write(out + "\n");
+
+  if (failUnderRaw) {
+    const failUnder = Number(failUnderRaw);
+    if (!Number.isInteger(failUnder) || failUnder < 1 || failUnder > 4) {
+      process.stderr.write(`[ERROR] --fail-under must be 1..4; got "${failUnderRaw}"\n`);
+      return 2;
+    }
+    if (report.overall.level < failUnder) {
+      process.stderr.write(
+        `Overall maturity ${report.overall.level} is below --fail-under=${failUnder}.\n`,
+      );
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+// Run if invoked directly
+import { fileURLToPath } from "node:url";
+const invoked =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (invoked) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/maturity.ts
+++ b/scripts/maturity.ts
@@ -166,7 +166,7 @@ export function formatMarkdown(report: MaturityReport): string {
     lines.push("");
   }
 
-  return lines.join("\n");
+  return lines.join("\n").trimEnd() + "\n";
 }
 
 function capitalize(s: string): string {
@@ -206,7 +206,9 @@ function main(argv: string[]): number {
   }
 
   const out = format === "markdown" ? formatMarkdown(report) : formatJson(report);
-  process.stdout.write(out + "\n");
+  // formatMarkdown returns content with a single trailing newline. Avoid
+  // appending a second.
+  process.stdout.write(format === "markdown" ? out : out + "\n");
 
   if (failUnderRaw) {
     const failUnder = Number(failUnderRaw);


### PR DESCRIPTION
## Summary

Closes #21. A focused, local-first scoring system that grades a plugin repo across four dimensions and produces a maturity level.

## Dimensions and checks (24 total)

| Dimension | Checks |
| --- | --- |
| **Compliance** | LICENSE, SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, CHANGELOG.md, authorship metadata |
| **Security** | .gitignore secret patterns, dep updater, audit in CI, REUSE config, no leaked secret files at root, SECURITY contact |
| **DevOps** | CI workflow present, \`permissions:\` block, Actions SHA-pinned, CODEOWNERS, issue/PR templates, pre-commit |
| **Quality** | task runner, test runner config, lint config, type config, test files exist, README usage section |

## Scoring + levels

\`score = (present + 0.5*partial) / (present + partial + missing)\`. \`n/a\` excluded from denominator.

| Range | Level |
| --- | --- |
| < 0.5 | Foundation (Level 1) |
| 0.5 – 0.69 | Governed (Level 2) |
| 0.7 – 0.89 | **Hardened (Level 3)** |
| ≥ 0.9 | Exemplary (Level 4) |

## This marketplace's self-report

\`\`\`
Overall:    Level 3 — Hardened (80%)
Compliance: Level 2 — Governed (50%)  [org-fallback caveat below]
Security:   Level 4 — Exemplary (100%)
DevOps:     Level 4 — Exemplary (100%)
Quality:    Level 4 — Exemplary (100%)
\`\`\`

Compliance reads low because the scanner can't see \`<org>/.github\` fallback files (SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md live in \`aida-core/.github\`). Org-fallback detection is filed as a deferred enhancement in ADR-0014.

## MVP scope cuts (deferred)

- Remote mode (\`--repo owner/name\` via gh api)
- Marketplace integration (validator rule rejecting plugins below min maturity)
- Badge endpoint
- Historical tracking
- Org-fallback detection
- Custom profiles

All documented in ADR-0014 "Deferred" section.

## Files

- \`scripts/maturity-checks.ts\` — 24 pure check functions
- \`scripts/maturity.ts\` — CLI + scoring + formatters
- \`scripts/maturity.test.ts\` — 30+ tests
- \`docs/adr/0014-plugin-maturity-model.md\` — ADR
- \`docs/maturity/README.md\` — usage docs
- \`docs/maturity/self-report.md\` — committed marketplace self-report
- \`make maturity\` + \`make maturity-report\` targets

## Local verification

- \`npm test\` ✓ (97/97 — 30+ new)
- \`npm run typecheck\` ✓
- \`make lint-yaml\` ✓
- \`make maturity\` ✓ — produces JSON report
- \`make maturity-report\` ✓ — regenerates the markdown snapshot

## CLI

\`\`\`bash
make maturity                          # JSON, current dir
npx tsx scripts/maturity.ts . --format markdown
npx tsx scripts/maturity.ts /path --fail-under 3
\`\`\`

## Test plan

- [ ] PR CI green (TypeScript runs the 30+ new tests including the regression guard that the marketplace itself stays ≥ Level 3)
- [ ] Post-merge: run \`make maturity-report\` periodically to check for drift
- [ ] Spot-check the JSON shape against the report in this PR