### PR TITLE
chore: Node 22 LTS bump + workflow re-eval on label changes

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20"
+          node-version: "22"
 
       - run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Include `labeled` / `unlabeled` so label-aware step conditions
+    # (e.g. the changelog job's `skip-changelog` opt-out) re-evaluate
+    # when a label is added to an already-open PR. Without these, the
+    # workflow keeps the event payload from the original trigger and
+    # ignores subsequent label changes.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
 
 # Least-privilege default for the workflow. Every job here only reads the
@@ -24,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20"
+          node-version: "22"
 
       - run: npm ci
 
@@ -52,7 +58,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20"
+          node-version: "22"
 
       # --ignore-scripts: don't run install hooks during a security check.
       - run: npm ci --ignore-scripts
@@ -71,7 +77,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20"
+          node-version: "22"
 
       - run: npm ci --ignore-scripts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped Node from 20 to **22 LTS** across CI workflows (ci.yml,
+  check-updates.yml, release.yml), `package.json#engines`
+  (`>=22.0.0`), and `@types/node` (`^22.0.0`). Node 20 hits EOL
+  in April 2026; 22 is the current LTS.
+- CI: added `labeled`, `unlabeled` to ci.yml's `pull_request`
+  event types. Previously the changelog job's `skip-changelog`
+  label opt-out wouldn't re-evaluate on already-open PRs because
+  the workflow froze the event payload at trigger time. The
+  expanded type list makes label changes retrigger the workflow.
+
 ### Added
 
 - ADR-0014: Plugin Maturity Model. Local-first, fast (no network),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,6 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## [Unreleased]
 
-### Changed
-
-- Bumped Node from 20 to **22 LTS** across CI workflows (ci.yml,
-  check-updates.yml, release.yml), `package.json#engines`
-  (`>=22.0.0`), and `@types/node` (`^22.0.0`). Node 20 hits EOL
-  in April 2026; 22 is the current LTS.
-- CI: added `labeled`, `unlabeled` to ci.yml's `pull_request`
-  event types. Previously the changelog job's `skip-changelog`
-  label opt-out wouldn't re-evaluate on already-open PRs because
-  the workflow froze the event payload at trigger time. The
-  expanded type list makes label changes retrigger the workflow.
-
 ### Added
 
 - ADR-0014: Plugin Maturity Model. Local-first, fast (no network),
@@ -347,6 +335,15 @@ and the marketplace adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Changed
 
+- Bumped Node from 20 to **22 LTS** across CI workflows (ci.yml,
+  check-updates.yml, release.yml), `package.json#engines`
+  (`>=22.0.0`), and `@types/node` (`^22.0.0`). Node 20 hits EOL
+  in April 2026; 22 is the current LTS.
+- CI: added `labeled`, `unlabeled` to ci.yml's `pull_request`
+  event types. Previously the changelog job's `skip-changelog`
+  label opt-out wouldn't re-evaluate on already-open PRs because
+  the workflow froze the event payload at trigger time. The
+  expanded type list makes label changes retrigger the workflow.
 - All CI workflows now declare top-level
   `permissions: contents: read` as a least-privilege baseline.
   Jobs that need broader scope (`check-updates.yml` opens PRs,

--- a/docs/maturity/self-report.md
+++ b/docs/maturity/self-report.md
@@ -4,7 +4,7 @@
 # Plugin Maturity Report
 
 - **Path:** `/Users/dx-aida-core/Developer/aida-core/aida-marketplace`
-- **Scanned:** 2026-05-23T21:06:27.734Z
+- **Scanned:** 2026-05-23T21:26:41.388Z
 
 ## Overall: Level 3 — Hardened (80%)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "aida-marketplace",
       "version": "0.0.0",
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "ajv": "^8.20.0",
         "tsx": "^4.7.0",
         "typescript": "^5.4.0"
       },
       "engines": {
-        "node": ">=20.11"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -460,9 +460,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20.11"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "check": "tsx scripts/update-marketplace.ts",
@@ -15,7 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "ajv": "^8.20.0",
     "tsx": "^4.7.0",
     "typescript": "^5.4.0"


### PR DESCRIPTION
## Summary

Two CI improvements bundled — both directly tied to your "anything to worry about" investigation on the Renovate dashboard.

### 1. Node 20 → 22 LTS

| File | Change |
| --- | --- |
| \`ci.yml\` (×3) | \`node-version: \"22\"\` |
| \`check-updates.yml\` | same |
| \`release.yml\` | same |
| \`package.json#engines\` | \`>=20.11\` → \`>=22.0.0\` |
| \`@types/node\` | \`^20.0.0\` → \`^22.0.0\` |
| \`package-lock.json\` | regenerated |

Node 20 hits EOL April 2026; 22 is the current LTS line (deliberately picking LTS over v24 \"current\" that Renovate's dashboard listed).

### 2. Workflow re-evaluates on label changes

\`ci.yml\`'s \`pull_request\` trigger now includes \`labeled, unlabeled\` in the types list. This fixes a real UX gotcha caught while investigating Renovate PRs:

- The changelog job's \`skip-changelog\` opt-out wouldn't take effect on already-open PRs
- GitHub Actions freezes the event payload at trigger time
- Adding a label triggered no re-run; re-running the failed job reused the old (label-free) payload

With \`labeled\`/\`unlabeled\` in the trigger list, applying or removing labels retriggers the workflow with the current label state. Affects the existing Renovate PRs #63 and #64 once they rebase onto main.

## Local verification

- \`npm test\` ✓ (97/97)
- \`npm run typecheck\` ✓ (with @types/node v22)
- \`npm run validate\` ✓ (5 passing, 1 skipped)
- \`npm audit --audit-level=high\` ✓ (0 vulnerabilities)
- \`make maturity\` ✓ (still Level 3 — Hardened, 80%)

## Test plan

- [ ] PR CI green on Node 22
- [ ] Post-merge: Renovate's next cycle rebases PRs #63 and #64 → they pick up Node 22 + the new labeled-trigger + the Audit job → they should mark green with \`skip-changelog\`